### PR TITLE
Issue #7 batch A: cheatsheet layout + submit-state on reload

### DIFF
--- a/static/js/inline-editor.js
+++ b/static/js/inline-editor.js
@@ -773,7 +773,39 @@ export async function mountInlineEditor(section, opts = {}) {
           out + (out && errStr ? "\n\n" : "") + errStr || "(no output)";
       }
     }
-    outputPanel.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    // Bring the output panel into view, but never scroll so far that
+    // the Run/Submit button row leaves the viewport. Without this guard
+    // a tall output panel pushes the buttons above the fold, and the
+    // user has to scroll back up to press Submit / re-Run.
+    scrollOutputIntoViewKeepingButtonsVisible();
+  }
+
+  function scrollOutputIntoViewKeepingButtonsVisible() {
+    if (!outputPanel) return;
+    const panelRect = outputPanel.getBoundingClientRect();
+    const vh = window.innerHeight || document.documentElement.clientHeight;
+    // Already comfortably in view? Nothing to do.
+    if (panelRect.top >= 0 && panelRect.top < vh * 0.85) return;
+
+    // Target: panel's top edge ~70% down the viewport (so the first few
+    // result lines are visible while the editor + buttons stay above).
+    const desired = panelRect.top - vh * 0.7;
+
+    // Cap so the button row stays in view. Use the run button's row as
+    // the anchor (submit lives in the same row, hidden until needed).
+    const anchor =
+      (runBtn && runBtn.parentElement) ||
+      (submitBtn && submitBtn.parentElement);
+    let delta = desired;
+    if (anchor) {
+      const anchorRect = anchor.getBoundingClientRect();
+      // Largest downward scroll allowed before the button row's top
+      // would cross the viewport top. Leave a small margin.
+      const maxDownward = Math.max(0, anchorRect.top - 16);
+      if (delta > 0) delta = Math.min(delta, maxDownward);
+    }
+    if (Math.abs(delta) < 4) return;
+    window.scrollBy({ top: delta, behavior: "smooth" });
   }
 
   function updateRunStatus(data) {
@@ -907,6 +939,14 @@ export async function mountInlineEditor(section, opts = {}) {
   // Filled in below if Submit is enabled. Called by the Run handler to
   // autosubmit when every test passes.
   let autosubmit = null;
+
+  // Persist the "Submitted ✓" state across reloads: the server marks
+  // the section with `data-completed="true"` when this step's most
+  // recent submission has all tests passing. Any subsequent edit clears
+  // it via the `persistExt` updateListener.
+  if (submitBtn && section.dataset.completed === "true") {
+    markSubmittedIndicator();
+  }
 
   if (runBtn) {
     runBtn.addEventListener("click", async () => {

--- a/static/js/inline-editor.js
+++ b/static/js/inline-editor.js
@@ -773,39 +773,7 @@ export async function mountInlineEditor(section, opts = {}) {
           out + (out && errStr ? "\n\n" : "") + errStr || "(no output)";
       }
     }
-    // Bring the output panel into view, but never scroll so far that
-    // the Run/Submit button row leaves the viewport. Without this guard
-    // a tall output panel pushes the buttons above the fold, and the
-    // user has to scroll back up to press Submit / re-Run.
-    scrollOutputIntoViewKeepingButtonsVisible();
-  }
-
-  function scrollOutputIntoViewKeepingButtonsVisible() {
-    if (!outputPanel) return;
-    const panelRect = outputPanel.getBoundingClientRect();
-    const vh = window.innerHeight || document.documentElement.clientHeight;
-    // Already comfortably in view? Nothing to do.
-    if (panelRect.top >= 0 && panelRect.top < vh * 0.85) return;
-
-    // Target: panel's top edge ~70% down the viewport (so the first few
-    // result lines are visible while the editor + buttons stay above).
-    const desired = panelRect.top - vh * 0.7;
-
-    // Cap so the button row stays in view. Use the run button's row as
-    // the anchor (submit lives in the same row, hidden until needed).
-    const anchor =
-      (runBtn && runBtn.parentElement) ||
-      (submitBtn && submitBtn.parentElement);
-    let delta = desired;
-    if (anchor) {
-      const anchorRect = anchor.getBoundingClientRect();
-      // Largest downward scroll allowed before the button row's top
-      // would cross the viewport top. Leave a small margin.
-      const maxDownward = Math.max(0, anchorRect.top - 16);
-      if (delta > 0) delta = Math.min(delta, maxDownward);
-    }
-    if (Math.abs(delta) < 4) return;
-    window.scrollBy({ top: delta, behavior: "smooth" });
+    outputPanel.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
 
   function updateRunStatus(data) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1331,11 +1331,25 @@
                 margin: 0 0 0.4rem;
                 font-size: 1.15rem;
             }
-            .cheatsheet-modal-body > p {
+            /* Only the intro paragraph (immediately after the h1) spans
+               all columns. In-section paragraphs (e.g. the prose around
+               the "What does my closure receive?" table) must stay in
+               column flow, otherwise each one forces a span-all break
+               and strands the surrounding sections in empty columns. */
+            .cheatsheet-modal-body > h1 + p {
                 column-span: all;
                 margin: 0 0 0.75rem;
                 font-size: 0.85rem;
                 color: var(--color-text-muted);
+            }
+            .cheatsheet-modal-body > p {
+                margin: 0 0 0.6rem;
+                font-size: 0.78rem;
+                line-height: 1.45;
+                break-inside: avoid;
+                /* Keep paragraphs glued to the heading or paragraph
+                   above so a section never splits across columns. */
+                break-before: avoid;
             }
             .cheatsheet-modal-body > h2 {
                 font-size: 0.9rem;
@@ -1346,9 +1360,26 @@
                 color: var(--color-text);
                 break-after: avoid;
             }
+            /* h3 is used for sub-sections (e.g. "What does my closure
+               receive?"). Style smaller than h2 and keep it attached to
+               the following paragraph/table. */
+            .cheatsheet-modal-body > h3 {
+                font-size: 0.82rem;
+                font-weight: 600;
+                margin: 0.4rem 0 0.25rem;
+                color: var(--color-text);
+                break-after: avoid;
+                break-inside: avoid;
+            }
             .cheatsheet-modal-body > h2,
+            .cheatsheet-modal-body > h3,
             .cheatsheet-modal-body > table {
                 break-inside: avoid;
+            }
+            /* Tables follow either an h2/h3 or an intro paragraph; pin
+               them to whatever comes before so they don't detach. */
+            .cheatsheet-modal-body > table {
+                break-before: avoid;
             }
             .cheatsheet-modal-body > table {
                 width: 100%;

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -155,6 +155,7 @@ progress_total > 0 %}
         class="exercise-section"
         data-step-id="{{ dom_id }}"
         data-exercise-key="{{ exercise_key }}"
+        data-completed="{% if *completed %}true{% else %}false{% endif %}"
     >
         <div class="exercise-section-head">
             <div>


### PR DESCRIPTION
Two fixes from the open items on #7.

### What's fixed

**Cheatsheet modal layout** (`templates/base.html`)
The multi-column flow was broken: `.cheatsheet-modal-body > p { column-span: all }` matched *every* direct-child paragraph, not just the intro. The wrapping prose around the 'What does my closure receive?' table forced span-all breaks that stranded Option/Result, Ownership, and Modules in empty columns (visible in the reporter's screenshot).
- Span-all now scoped to `> h1 + p`.
- In-section paragraphs get `break-inside` / `break-before: avoid` so they stay glued to their heading.
- Tables get `break-before: avoid` so they don't detach from their h2/h3/paragraph.
- New styling for `> h3` (used by sub-sections like 'What does my closure receive?'); it had no styling before.

**Submit state persists across reloads** (`static/js/inline-editor.js`, `templates/exercise.html`)
The server already knew each step's `completed` status, but the editor JS didn't. Now `<section>` emits `data-completed="true|false"` and the editor flips into 'Submitted ✓' on mount when set. The existing edit-listener clears it on first edit, so the next Run/Submit is fresh.

### Validated locally
- `cargo build --bin server` clean.
- Server starts; `/`, `/cheatsheet`, `/cheatsheet/fragment`, `/exercise/00_integers` all return 200.
- `data-completed` attribute renders on each exercise section.
- New `> h1 + p` selector is present in served HTML.

### Deferred from this batch
- **Scroll-on-Run** — reverted on request; the existing `scrollIntoView({block:'nearest'})` is fine.
- **Hover über Links wechselt den Cursor nicht** — couldn't reproduce a specific case where a real `<a href>` lacks the pointer cursor. Need a concrete example.
- **Übungsauswahl-Dropdown flackert beim Hovern** — the picker is click-toggled; couldn't reproduce a flicker locally. Need a video or steps from the reporter.

All three remain open in the #7 triage checklist.

Closes more of #7.