### PR TITLE
Issue #7: Title Case + unified chapter-list TOC

### DIFF
--- a/examples/01_strings_and_chars/1_intro.md
+++ b/examples/01_strings_and_chars/1_intro.md
@@ -1,4 +1,4 @@
-# Strings, &str, and chars
+# Strings, &str, and Chars
 
 *An `i32` walks up to a `String` and asks for its number. The `String` replies: "Sorry, you're not my type."*
 

--- a/examples/02_conditionals_and_loops/1_intro.md
+++ b/examples/02_conditionals_and_loops/1_intro.md
@@ -1,4 +1,4 @@
-# Conditionals and loops
+# Conditionals and Loops
 
 *Why did the Rust loop break up with the condition? It said "I just need some space."*
 

--- a/examples/04_enums_and_pattern_matching/1_intro.md
+++ b/examples/04_enums_and_pattern_matching/1_intro.md
@@ -1,4 +1,4 @@
-# Enums and pattern matching
+# Enums and Pattern Matching
 
 *“Dad, why is my sister’s name Rose?”  
 “Because your mother loves roses.”  

--- a/examples/07_tuples_and_destructuring/1_intro.md
+++ b/examples/07_tuples_and_destructuring/1_intro.md
@@ -1,4 +1,4 @@
-# Tuples and destructuring
+# Tuples and Destructuring
 
 A tuple is a fixed-size group of values. Unlike a `Vec`, the elements can
 be different types, and the size is part of the type.

--- a/examples/08_option/1_intro.md
+++ b/examples/08_option/1_intro.md
@@ -1,4 +1,4 @@
-# Option<T>: when a value might be missing
+# Option<T>: When a Value Might Be Missing
 
 *I looked for a joke about null pointers in Rust, but there was `None`.*
 

--- a/examples/09_result/1_intro.md
+++ b/examples/09_result/1_intro.md
@@ -1,4 +1,4 @@
-# Result<T, E>: when an operation might fail
+# Result<T, E>: When an Operation Might Fail
 
 *Failure is not an `Option<T>`, but a `Result<T, E>`.*
 

--- a/examples/10_ownership_and_borrowing/1_intro.md
+++ b/examples/10_ownership_and_borrowing/1_intro.md
@@ -1,4 +1,4 @@
-# Ownership and borrowing
+# Ownership and Borrowing
 
 *Why are Rust developers so frugal? They prefer to borrow.*
 

--- a/examples/11_structs_and_methods/1_intro.md
+++ b/examples/11_structs_and_methods/1_intro.md
@@ -1,4 +1,4 @@
-# Structs and methods
+# Structs and Methods
 
 A `struct` groups related fields under a single named type. Once you have
 a struct, you can attach methods to it with an `impl` block.

--- a/examples/13_smart_pointers/1_intro.md
+++ b/examples/13_smart_pointers/1_intro.md
@@ -1,4 +1,4 @@
-# Smart pointers
+# Smart Pointers
 
 *A pointer that cleans up after itself walks into a scope. Nothing
 leaks.*

--- a/examples/15_password_validator/1_intro.md
+++ b/examples/15_password_validator/1_intro.md
@@ -1,4 +1,4 @@
-# A creative break
+# A Creative Break
 
 You might not have noticed yet, but, quietly, like a beautiful magpie collecting
 shiny things, you've acquired the skills to write a lot of helpful Rust programs

--- a/examples/16_question_mark_operator/1_intro.md
+++ b/examples/16_question_mark_operator/1_intro.md
@@ -1,4 +1,4 @@
-# The `?` operator
+# The `?` Operator
 
 Working with `Result` quickly becomes verbose if every call needs a
 match-then-return:

--- a/examples/17_modules_and_visibility/1_intro.md
+++ b/examples/17_modules_and_visibility/1_intro.md
@@ -1,4 +1,4 @@
-# Modules and visibility
+# Modules and Visibility
 
 Modules are how Rust organizes code into namespaces. They give you two
 things: a way to group related items together, and a way to control

--- a/examples/18_word_counter/1_intro.md
+++ b/examples/18_word_counter/1_intro.md
@@ -1,4 +1,4 @@
-# Putting it together
+# Putting It Together
 
 This chapter doesn't introduce a new concept. It combines strings,
 collections, and iterators into one small program: count words in a

--- a/examples/19_environment_file_parser/1_intro.md
+++ b/examples/19_environment_file_parser/1_intro.md
@@ -1,4 +1,4 @@
-# Parsing structured text and generics
+# Parsing Structured Text and Generics
 
 *You have a problem. You decide to use generics. Now you have a `Problem<T> where T: Clone + Send + Sync + 'static`.*
 

--- a/examples/20_csv_parser/1_intro.md
+++ b/examples/20_csv_parser/1_intro.md
@@ -1,4 +1,4 @@
-# State machines and stateful parsing
+# State Machines and Stateful Parsing
 
 CSV looks easy until you hit quoted fields with commas inside, or
 escaped quotes inside quoted fields. The trick is to walk the input

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -152,9 +152,12 @@ struct UiExerciseStatus {
 struct DashboardTemplate {
     participant_name: Option<String>,
     ulid: Option<String>,
-    /// Rows for the shared `partials/chapter_list.html` partial.
-    /// Same shape as the exercise page's TOC; `current` is always
-    /// `false` here (the homepage has no current chapter).
+    /// One entry per chapter, in display order. Renders the bottom
+    /// table of contents on the homepage via the shared
+    /// `templates/partials/chapter_list.html` partial — the same one
+    /// each exercise page uses for its "All exercises" nav, so the
+    /// two stay visually identical. `current` is always `false`
+    /// here because the homepage isn't any one chapter.
     dots: Vec<ProgressDot>,
     /// Slug of the first chapter the participant hasn't completed yet,
     /// or the first chapter overall if they're brand new / fully done.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -152,7 +152,10 @@ struct UiExerciseStatus {
 struct DashboardTemplate {
     participant_name: Option<String>,
     ulid: Option<String>,
-    exercises: Vec<ExerciseProgress>,
+    /// Rows for the shared `partials/chapter_list.html` partial.
+    /// Same shape as the exercise page's TOC; `current` is always
+    /// `false` here (the homepage has no current chapter).
+    dots: Vec<ProgressDot>,
     /// Slug of the first chapter the participant hasn't completed yet,
     /// or the first chapter overall if they're brand new / fully done.
     /// Used by the "Start" call-to-action.
@@ -602,6 +605,27 @@ async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+/// Build chapter-list rows for the homepage from per-exercise
+/// progress. Mirrors the dot construction in `render_exercise_page`
+/// so both pages feed the same `partials/chapter_list.html` partial.
+/// `current` is always `false` on the homepage.
+fn dots_from_exercises(exercises: &[ExerciseProgress]) -> Vec<ProgressDot> {
+    exercises
+        .iter()
+        .map(|e| ProgressDot {
+            slug: e.name.clone(),
+            number: e.number,
+            title: e.title.clone(),
+            attempted: !e.submissions.is_empty(),
+            completed: e.completed,
+            perfected: e.perfected,
+            current: false,
+            is_quiz: e.is_quiz,
+            has_exercises: e.has_exercises,
+        })
+        .collect()
+}
+
 /// Anonymous dashboard at `/`.
 ///
 /// Renders the same `dashboard.html` template the participant view
@@ -649,7 +673,7 @@ async fn anonymous_dashboard(
     let template = DashboardTemplate {
         participant_name: None,
         ulid: None,
-        exercises,
+        dots: dots_from_exercises(&exercises),
         next_slug,
         next_label,
         next_chapter_number,
@@ -877,7 +901,7 @@ async fn participant_dashboard(
     let template = DashboardTemplate {
         participant_name: Some(participant.name),
         ulid: Some(ulid.clone()),
-        exercises,
+        dots: dots_from_exercises(&exercises),
         next_slug,
         next_label,
         next_chapter_number,

--- a/static/cheatsheet.md
+++ b/static/cheatsheet.md
@@ -4,7 +4,7 @@ A short, opinionated quick-reference of the syntax this course uses.
 Inspired by [cheats.rs](https://cheats.rs/), trimmed to the essentials.
 Press `?` from any page to bring this up; `Esc` to close.
 
-## Variables and types
+## Variables and Types
 
 | Syntax | Meaning |
 | --- | --- |
@@ -24,7 +24,7 @@ Press `?` from any page to bring this up; `Esc` to close.
 | `println!("{s} {n}");` | Print to stdout, with a newline. |
 | Take `&str` in, return `String` out | Rule of thumb for function signatures. |
 
-## Control flow
+## Control Flow
 
 | Syntax | Meaning |
 | --- | --- |
@@ -57,7 +57,7 @@ Press `?` from any page to bring this up; `Esc` to close.
 | `HashMap<K, V>` | Hash map. `use std::collections::HashMap;` |
 | `m.insert(k, v);` `m.get(&k);` | Insert; lookup returns `Option<&V>`. |
 
-## Functions and closures
+## Functions and Closures
 
 | Syntax | Meaning |
 | --- | --- |
@@ -66,7 +66,7 @@ Press `?` from any page to bring this up; `Esc` to close.
 | `\|x: i32\| -> i32 { x + 1 }` | Closure with explicit types and a body block. |
 | `Fn`, `FnMut`, `FnOnce` | Closure traits, in order of how much they capture. |
 
-## Ownership and borrowing
+## Ownership and Borrowing
 
 | Syntax | Meaning |
 | --- | --- |
@@ -76,7 +76,7 @@ Press `?` from any page to bring this up; `Esc` to close.
 | `fn consume(s: String) { ... }` | Takes ownership; original binding becomes invalid. |
 | Rule | At any time: many `&` *or* one `&mut`, never both. |
 
-## Structs, enums, methods
+## Structs, Enums, Methods
 
 | Syntax | Meaning |
 | --- | --- |
@@ -117,7 +117,7 @@ Direct comparisons (`==`, `<`, `>`) don't, which is why you sometimes
 need `**` or `&&` to make the types meet.
 
 
-## Error handling with `?`
+## Error Handling with `?`
 
 | Syntax | Meaning |
 | --- | --- |
@@ -125,7 +125,7 @@ need `**` or `&&` to make the types meet.
 | `Result<T, Box<dyn Error>>` | "Any error type", common in `main`. |
 | `?` requires a matching return type | Function must return `Result` or `Option`. |
 
-## Modules and visibility
+## Modules and Visibility
 
 | Syntax | Meaning |
 | --- | --- |
@@ -135,7 +135,7 @@ need `**` or `&&` to make the types meet.
 | `pub(crate) fn ...` | Public within this crate only. |
 | (no keyword) | Private to the current module. |
 
-## Traits and generics (just enough)
+## Traits and Generics (Just Enough)
 
 | Syntax | Meaning |
 | --- | --- |
@@ -143,7 +143,7 @@ need `**` or `&&` to make the types meet.
 | `impl Display for User { ... }` | Implement a trait for your type. |
 | `Box<dyn Trait>` | Heap-allocated trait object (dynamic dispatch). |
 
-## Cargo commands
+## Cargo Commands
 
 | Command | Purpose |
 | --- | --- |
@@ -155,7 +155,7 @@ need `**` or `&&` to make the types meet.
 | `cargo fmt` | Auto-format with rustfmt. |
 | `cargo clippy -- -D warnings` | Lint, fail on warnings. |
 
-## Where to look next
+## Where to Look Next
 
 [`std` docs](https://doc.rust-lang.org/std/) ·
 [Rust by Example](https://doc.rust-lang.org/rust-by-example/) ·

--- a/templates/base.html
+++ b/templates/base.html
@@ -1240,6 +1240,111 @@
                 background: var(--color-error);
             }
 
+            /* ---------- Shared chapter list ---------- */
+            /* Rendered by `templates/partials/chapter_list.html` on both
+               the homepage and every exercise page. One set of styles,
+               two consumers. */
+            .chapter-list {
+                margin: 3rem auto 0;
+                display: grid;
+                grid-template-columns: 1fr;
+                gap: 0 2rem;
+                max-width: 60rem;
+            }
+            @media (min-width: 720px) {
+                .chapter-list {
+                    grid-template-columns: 1fr 1fr;
+                    grid-auto-flow: column;
+                    grid-template-rows: repeat(var(--chapter-rows, 10), auto);
+                }
+            }
+            .chapter-row {
+                display: grid;
+                grid-template-columns: 2.25rem 1fr auto;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.65rem 0.75rem;
+                border-top: 1px solid var(--color-border);
+                color: var(--color-primary, #0969da);
+                text-decoration: none;
+                font-size: 0.95rem;
+                text-transform: uppercase;
+                letter-spacing: 0.04em;
+                transition: background-color 120ms;
+            }
+            .chapter-row:last-child {
+                border-bottom: 1px solid var(--color-border);
+            }
+            .chapter-row:hover,
+            .chapter-row:focus-visible {
+                background-color: var(--color-background);
+            }
+            .chapter-row .chapter-num {
+                color: var(--color-text-muted);
+                font-variant-numeric: tabular-nums;
+                font-weight: 500;
+            }
+            .chapter-row .chapter-title {
+                font-weight: 500;
+            }
+            .chapter-row .chapter-mark {
+                width: 0.6rem;
+                height: 0.6rem;
+                border-radius: 999px;
+                background: transparent;
+                border: 1px solid var(--color-border);
+            }
+            .chapter-row.attempted {
+                background-color: rgba(125, 125, 125, 0.06);
+            }
+            .chapter-row.attempted .chapter-mark {
+                background: var(--color-text-muted);
+                border-color: var(--color-text-muted);
+                opacity: 0.45;
+            }
+            .chapter-row.completed {
+                background-color: rgba(46, 125, 50, 0.07);
+            }
+            .chapter-row.completed .chapter-mark {
+                background: var(--color-success, #2e7d32);
+                border-color: var(--color-success, #2e7d32);
+                opacity: 1;
+            }
+            .chapter-row.perfected {
+                background-color: rgba(241, 196, 15, 0.1);
+            }
+            .chapter-row.perfected .chapter-mark {
+                background: #f1c40f;
+                border-color: #f1c40f;
+            }
+            .chapter-row.completed:hover,
+            .chapter-row.completed:focus-visible {
+                background-color: rgba(46, 125, 50, 0.13);
+            }
+            .chapter-row.perfected:hover,
+            .chapter-row.perfected:focus-visible {
+                background-color: rgba(241, 196, 15, 0.18);
+            }
+            .chapter-row.current {
+                background-color: var(--color-background);
+                color: var(--color-text);
+                font-weight: 700;
+                box-shadow: inset 3px 0 0 var(--color-primary, #0969da);
+            }
+            .chapter-row.current .chapter-num {
+                color: var(--color-text);
+                font-weight: 700;
+            }
+            .chapter-row.current.completed {
+                background-color: rgba(46, 125, 50, 0.12);
+            }
+            .chapter-row.current.perfected {
+                background-color: rgba(241, 196, 15, 0.18);
+            }
+            .chapter-row.quiz .chapter-title {
+                font-style: italic;
+            }
+
             /* ---------- Cheatsheet modal ---------- */
             .cheatsheet-modal {
                 position: fixed;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -278,45 +278,7 @@ fn main() {
     </section>
     {% endmatch %}
 
-    <section class="book-toc" aria-label="Table of contents">
-        <div class="book-toc-eyebrow">Contents</div>
-        <ol class="book-toc-list">
-            {% for exercise in exercises %} {% if exercise.is_quiz %}
-            <li
-                class="book-toc-row{% if exercise.completed %} is-completed{% endif %}{% if exercise.perfected %} is-perfected{% endif %} is-quiz"
-            >
-                <span class="book-toc-num">{{ exercise.number }}.</span>
-                <a
-                    class="book-toc-link"
-                    href="/static/quiz.html"
-                    target="_blank"
-                >
-                    <span class="book-toc-title">{{ exercise.title }}</span>
-                </a>
-                <span class="book-toc-mark" aria-hidden="true"></span>
-            </li>
-            {% else %}
-            <li
-                class="book-toc-row{% if exercise.completed %} is-completed{% endif %}{% if exercise.perfected %} is-perfected{% endif %}"
-            >
-                <span class="book-toc-num">{{ exercise.number }}.</span>
-                {% match ulid %} {% when Some with (u) %}
-                <a
-                    class="book-toc-link"
-                    href="/exercise/{{ u }}/{{ exercise.name }}"
-                >
-                    <span class="book-toc-title">{{ exercise.title }}</span>
-                </a>
-                {% when None %}
-                <a class="book-toc-link" href="/exercise/{{ exercise.name }}">
-                    <span class="book-toc-title">{{ exercise.title }}</span>
-                </a>
-                {% endmatch %}
-                <span class="book-toc-mark" aria-hidden="true"></span>
-            </li>
-            {% endif %} {% endfor %}
-        </ol>
-    </section>
+    {% include "partials/chapter_list.html" %}
 
     {% if !next_slug.is_empty() %} {% match participant_name %} {% when Some
     with (_n) %}
@@ -639,88 +601,6 @@ fn main() {
         text-decoration: underline;
     }
 
-    /* ---------- Table of contents ---------- */
-    .book-toc {
-        margin: 0 auto 4rem;
-        max-width: 52rem;
-    }
-    .book-toc-eyebrow {
-        font-size: 0.72rem;
-        font-weight: 700;
-        letter-spacing: 0.24em;
-        text-transform: uppercase;
-        color: var(--color-text-muted);
-        text-align: center;
-        margin-bottom: 1.5rem;
-        padding-bottom: 1.5rem;
-        border-bottom: 1px solid var(--color-border);
-    }
-    .book-toc-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: grid;
-        grid-template-columns: 1fr;
-        column-gap: 3rem;
-        row-gap: 0.15rem;
-    }
-    @media (min-width: 860px) {
-        .book-toc-list {
-            grid-template-columns: 1fr 1fr;
-        }
-    }
-    .book-toc-row {
-        display: grid;
-        grid-template-columns: 2.25rem 1fr auto;
-        align-items: baseline;
-        gap: 0.75rem;
-        padding: 0.75rem 0;
-    }
-    .book-toc-num {
-        text-align: right;
-        font-variant-numeric: tabular-nums;
-        color: var(--color-text-muted);
-        font-weight: 500;
-        font-size: 0.95rem;
-    }
-    .book-toc-link {
-        color: var(--color-text);
-        text-decoration: none;
-        font-weight: 500;
-        font-size: 1rem;
-        line-height: 1.4;
-        min-width: 0;
-        transition: color 120ms ease;
-    }
-    .book-toc-link:hover,
-    .book-toc-link:focus-visible {
-        color: var(--color-primary);
-    }
-    .book-toc-title {
-        display: inline;
-    }
-    .book-toc-mark {
-        display: inline-block;
-        width: 0.55rem;
-        height: 0.55rem;
-        border-radius: 999px;
-        background: transparent;
-        border: 1px solid var(--color-border);
-        align-self: center;
-    }
-    .book-toc-row.is-completed .book-toc-mark {
-        background: var(--color-success, #2e7d32);
-        border-color: var(--color-success, #2e7d32);
-    }
-    .book-toc-row.is-perfected .book-toc-mark {
-        background: #f1c40f;
-        border-color: #f1c40f;
-        box-shadow: 0 0 0 2px rgba(241, 196, 15, 0.18);
-    }
-    .book-toc-row.is-quiz .book-toc-link {
-        font-style: italic;
-    }
-
     /* ---------- Call to action ---------- */
     .book-cta {
         text-align: center;
@@ -769,14 +649,6 @@ fn main() {
     .unknown-token-toast-close:hover,
     .unknown-token-toast-close:focus-visible {
         color: var(--color-text);
-    }
-
-    /* ---------- Responsive ---------- */
-    @media (max-width: 600px) {
-        .book-toc-row {
-            grid-template-columns: 2rem 1fr auto;
-            gap: 0.6rem;
-        }
     }
 </style>
 {% endblock %}

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -546,43 +546,8 @@ progress_total > 0 %}
         </a>
         {% endmatch %}
     </section>
-    {% endif %} {% when None %} {% endmatch %} {% if exercise.shows_toc() %}
-    <nav
-        class="chapter-list"
-        aria-label="All exercises"
-        style="--chapter-rows: {{ (dots.len() + 1) / 2 }}"
-    >
-        {% for d in dots %} {% if d.current %}
-        <span
-            class="chapter-row current{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
-            id="current-chapter-row"
-            aria-current="page"
-        >
-            <span class="chapter-num">{{ d.number }}</span>
-            <span class="chapter-title">{{ d.title }}</span>
-            <span class="chapter-mark" aria-hidden="true"></span>
-        </span>
-        {% else %} {% match ulid %} {% when Some with (u) %}
-        <a
-            href="/exercise/{{ u }}/{{ d.slug }}"
-            class="chapter-row{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
-        >
-            <span class="chapter-num">{{ d.number }}</span>
-            <span class="chapter-title">{{ d.title }}</span>
-            <span class="chapter-mark" aria-hidden="true"></span>
-        </a>
-        {% when None %}
-        <a
-            href="/exercise/{{ d.slug }}"
-            class="chapter-row{% if d.is_quiz %} quiz{% endif %}"
-        >
-            <span class="chapter-num">{{ d.number }}</span>
-            <span class="chapter-title">{{ d.title }}</span>
-            <span class="chapter-mark" aria-hidden="true"></span>
-        </a>
-        {% endmatch %} {% endif %} {% endfor %}
-    </nav>
-    {% endif %}
+    {% endif %} {% when None %} {% endmatch %} {% if exercise.shows_toc() %} {%
+    include "partials/chapter_list.html" %} {% endif %}
 </div>
 
 <script type="module">
@@ -1455,103 +1420,10 @@ progress_total > 0 %}
         transform: translateX(0.2rem);
     }
 
-    .chapter-list {
-        margin: 3rem auto 0;
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: 0 2rem;
-        max-width: 60rem;
-    }
-    @media (min-width: 720px) {
-        .chapter-list {
-            grid-template-columns: 1fr 1fr;
-            grid-auto-flow: column;
-            grid-template-rows: repeat(var(--chapter-rows, 10), auto);
-        }
-    }
-    .chapter-row {
-        display: grid;
-        grid-template-columns: 2.25rem 1fr auto;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.65rem 0.75rem;
-        border-top: 1px solid var(--color-border);
-        color: var(--color-primary, #0969da);
-        text-decoration: none;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        transition: background-color 120ms;
-    }
-    .chapter-row:last-child {
-        border-bottom: 1px solid var(--color-border);
-    }
-    .chapter-row:hover,
-    .chapter-row:focus-visible {
-        background-color: var(--color-background);
-    }
-    .chapter-row .chapter-num {
-        color: var(--color-text-muted);
-        font-variant-numeric: tabular-nums;
-        font-weight: 500;
-    }
-    .chapter-row .chapter-title {
-        font-weight: 500;
-    }
-    .chapter-row .chapter-mark {
-        width: 0.6rem;
-        height: 0.6rem;
-        border-radius: 999px;
-        background: transparent;
-        border: 1px solid var(--color-border);
-    }
-    .chapter-row.attempted {
-        background-color: rgba(125, 125, 125, 0.06);
-    }
-    .chapter-row.attempted .chapter-mark {
-        background: var(--color-text-muted);
-        border-color: var(--color-text-muted);
-        opacity: 0.45;
-    }
-    .chapter-row.completed {
-        background-color: rgba(46, 125, 50, 0.07);
-    }
-    .chapter-row.completed .chapter-mark {
-        background: var(--color-success, #2e7d32);
-        border-color: var(--color-success, #2e7d32);
-        opacity: 1;
-    }
-    .chapter-row.perfected {
-        background-color: rgba(241, 196, 15, 0.1);
-    }
-    .chapter-row.perfected .chapter-mark {
-        background: #f1c40f;
-        border-color: #f1c40f;
-    }
-    .chapter-row.completed:hover,
-    .chapter-row.completed:focus-visible {
-        background-color: rgba(46, 125, 50, 0.13);
-    }
-    .chapter-row.perfected:hover,
-    .chapter-row.perfected:focus-visible {
-        background-color: rgba(241, 196, 15, 0.18);
-    }
-    .chapter-row.current {
-        background-color: var(--color-background);
-        color: var(--color-text);
-        font-weight: 700;
-        box-shadow: inset 3px 0 0 var(--color-primary, #0969da);
-    }
-    .chapter-row.current .chapter-num {
-        color: var(--color-text);
-        font-weight: 700;
-    }
-    .chapter-row.current.completed {
-        background-color: rgba(46, 125, 50, 0.12);
-    }
-    .chapter-row.current.perfected {
-        background-color: rgba(241, 196, 15, 0.18);
-    }
+    /* The bottom "All exercises" chapter list and the homepage TOC both
+       render through `templates/partials/chapter_list.html`. The shared
+       `.chapter-list` / `.chapter-row` styles live in base.html. */
+
     /* The hint is a disclosure widget, not a UI card. Collapsed state
        is a quiet text trigger (icon + label, no border/background) so
        it never competes visually with the editor section or run output
@@ -1667,9 +1539,6 @@ progress_total > 0 %}
     .prose-copy-btn svg {
         width: 14px;
         height: 14px;
-    }
-    .chapter-row.quiz .chapter-title {
-        font-style: italic;
     }
 </style>
 {% endblock %}

--- a/templates/partials/chapter_list.html
+++ b/templates/partials/chapter_list.html
@@ -1,0 +1,57 @@
+{#
+    Shared chapter list partial.
+
+    Used by the homepage and every exercise page so both render the
+    same TOC markup and pick up the same `.chapter-list` / `.chapter-row`
+    styles from base.html.
+
+    Required template variables:
+      - dots: a list of ProgressDot rows (one per chapter, in order)
+      - ulid: Option of String. When Some, links carry the participant
+        prefix; when None, links go to the anonymous /exercise/SLUG.
+
+    At most one row may have `current = true`. That row renders as a
+    non-link span with id `current-chapter-row` so
+    `static/js/inline-editor.js` can refresh completion state after a
+    passing Run on the chapter page.
+#}
+<nav
+    class="chapter-list"
+    aria-label="All exercises"
+    style="--chapter-rows: {{ (dots.len() + 1) / 2 }}"
+>
+    {% for d in dots %}
+        {% if d.current %}
+        <span
+            class="chapter-row current{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
+            id="current-chapter-row"
+            aria-current="page"
+        >
+            <span class="chapter-num">{{ d.number }}</span>
+            <span class="chapter-title">{{ d.title }}</span>
+            <span class="chapter-mark" aria-hidden="true"></span>
+        </span>
+        {% else %}
+            {% match ulid %}
+            {% when Some with (u) %}
+            <a
+                href="/exercise/{{ u }}/{{ d.slug }}"
+                class="chapter-row{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
+            >
+                <span class="chapter-num">{{ d.number }}</span>
+                <span class="chapter-title">{{ d.title }}</span>
+                <span class="chapter-mark" aria-hidden="true"></span>
+            </a>
+            {% when None %}
+            <a
+                href="/exercise/{{ d.slug }}"
+                class="chapter-row{% if d.is_quiz %} quiz{% endif %}"
+            >
+                <span class="chapter-num">{{ d.number }}</span>
+                <span class="chapter-title">{{ d.title }}</span>
+                <span class="chapter-mark" aria-hidden="true"></span>
+            </a>
+            {% endmatch %}
+        {% endif %}
+    {% endfor %}
+</nav>


### PR DESCRIPTION
Two batch-B items from #7.

### 1. Title Case across chapter titles and cheatsheet

Markdown-only.

- Rewrote the H1 in 15 chapter intros (`examples/*/1_intro.md`) to Chicago-style Title Case: "Conditionals and Loops", "Putting It Together", "When a Value Might Be Missing", etc. Articles, short prepositions, and conjunctions stay lowercase ("a", "an", "the", "and", "or", "in", "on", "to", "of", …). Technical fragments are left untouched (`&str`, `?`, `HashMaps`).
- Rewrote the H2 section headers in `static/cheatsheet.md` to match. The closure-receive H3 stays sentence-case because it's a question.

The H1 is the source of truth for both the TOC label and the on-page heading on each chapter, so the new titles propagate everywhere automatically.

### 2. One TOC, two consumers

The homepage and the per-chapter "All exercises" nav rendered two different TOCs — bordered cards with a "Contents" eyebrow on `/` vs. flat uppercase blue rows on `/exercise/{slug}` — backed by two copies of the markup and two CSS blocks. Collapsed to one source of truth:

- New `templates/partials/chapter_list.html` owns the markup; both `dashboard.html` and `exercise.html` just `{% include %}` it.
- Shared `.chapter-list` / `.chapter-row` styles moved into `base.html`.
- Dropped the homepage's bespoke `.book-toc*` CSS (~95 lines) and the "Chapter / Lesson / Quiz" pill (an earlier addition that was never on the chapter-page TOC).
- `DashboardTemplate` gained `dots: Vec<ProgressDot>` via a small `dots_from_exercises` helper so it feeds the partial the same shape `render_exercise_page` already builds.

### Validated locally

`cargo build --bin server` clean. `cargo test --no-run` clean.

### Closes from #7

- Titel in Title Case formatieren
- Homepage TOC inconsistent with per-chapter TOC (follow-up)