### PR TITLE
Playground: run main() instead of cargo test, add fullscreen toggle

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1946,12 +1946,23 @@ async fn api_status(
 }
 
 /// Request body for `/api/run`. We accept any source code; the slug is
-/// optional and only used for logging.
+/// optional and only used for logging. `tests` defaults to `true` so
+/// exercise editors continue to compile with `--tests` (which surfaces
+/// `#[test]` results and is also how the Playground exposes a few of
+/// our test-only diagnostics). The standalone scratchpad sends
+/// `tests = false` so it runs `main()` and the user actually sees their
+/// `println!` / `dbg!` output.
 #[derive(Deserialize)]
 struct RunRequest {
     code: String,
     #[serde(default)]
     slug: Option<String>,
+    #[serde(default = "default_tests")]
+    tests: bool,
+}
+
+const fn default_tests() -> bool {
+    true
 }
 
 /// Response type mirroring the Playground `/execute` endpoint, plus a
@@ -1983,7 +1994,7 @@ async fn api_run(Json(req): Json<RunRequest>) -> Result<Json<RunResponse>, Statu
         "mode": "debug",
         "edition": "2024",
         "crateType": "bin",
-        "tests": true,
+        "tests": req.tests,
         "backtrace": false,
         "code": req.code,
     });

--- a/static/js/inline-editor.js
+++ b/static/js/inline-editor.js
@@ -51,6 +51,10 @@
 //   syntaxHighlightOutput  -> mount a read-only CM6 view inside
 //                             `data-role="output-stderr"` to colourise
 //                             cargo output (defaults to features.testResults)
+//   runWithoutTests        -> send `tests: false` to /api/run so the
+//                             upstream Playground runs `main()` instead of
+//                             `cargo test`. The scratchpad uses this so
+//                             `println!` / `dbg!` output actually shows up.
 //
 // Vim toggle is *global* across every mounted editor on the page (it would
 // be jarring to have one section in vim mode and another not). Each mount
@@ -306,6 +310,7 @@ export async function mountInlineEditor(section, opts = {}) {
   const draftKey = features.draftKey || null;
   const wantsTestResults = features.testResults !== false && !!testList;
   const wantsHighlightOutput = features.syntaxHighlightOutput === true;
+  const runWithoutTests = features.runWithoutTests === true;
 
   const persistDraft = (text) => {
     if (!draftKey) return;
@@ -783,9 +788,13 @@ export async function mountInlineEditor(section, opts = {}) {
 
     if (runStatus) {
       if (total === 0) {
-        runStatus.textContent = data.success
-          ? "Compiled. No tests ran."
-          : "Did not compile.";
+        if (runWithoutTests) {
+          runStatus.textContent = data.success ? "Ran." : "Did not compile.";
+        } else {
+          runStatus.textContent = data.success
+            ? "Compiled. No tests ran."
+            : "Did not compile.";
+        }
         runStatus.style.color = data.success
           ? "var(--color-text-muted)"
           : "var(--color-error, #c62828)";
@@ -800,7 +809,11 @@ export async function mountInlineEditor(section, opts = {}) {
 
     if (total === 0) {
       setActionStatus(
-        data.success ? "Compiled" : "Did not compile",
+        data.success
+          ? runWithoutTests
+            ? "Ran"
+            : "Compiled"
+          : "Did not compile",
         data.success ? "neutral" : "fail",
       );
     } else if (passed === total) {
@@ -838,10 +851,12 @@ export async function mountInlineEditor(section, opts = {}) {
     if (runSpinner) runSpinner.style.display = "inline-block";
     clearActionStatus();
     try {
+      const payload = { code, slug: exerciseKey };
+      if (runWithoutTests) payload.tests = false;
       const resp = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code, slug: exerciseKey }),
+        body: JSON.stringify(payload),
       });
       if (!resp.ok) {
         if (runStatus) {

--- a/static/js/inline-editor.js
+++ b/static/js/inline-editor.js
@@ -378,7 +378,8 @@ export async function mountInlineEditor(section, opts = {}) {
       Decoration,
       ViewPlugin,
     } = view;
-    const { syntaxHighlighting, bracketMatching, indentOnInput } = lang;
+    const { syntaxHighlighting, bracketMatching, indentOnInput, indentUnit } =
+      lang;
     const { defaultKeymap, history, historyKeymap, indentWithTab } = commands;
     const {
       autocompletion,
@@ -493,6 +494,10 @@ export async function mountInlineEditor(section, opts = {}) {
       history(),
       drawSelection(),
       indentOnInput(),
+      // Match Zed / rustfmt: 4-space indent. CM6 defaults to 2, which made
+      // newlines inside `fn`/`impl` blocks indent half as far as the
+      // surrounding (rustfmt'd) code in the same buffer.
+      indentUnit.of("    "),
       bracketMatching(),
       syntaxHighlighting(proseHighlightStyle, { fallback: true }),
       closeBrackets(),

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -80,20 +80,20 @@ endblock %} {% block content %}
                 </button>
                 <button
                     type="button"
-                    class="btn btn-secondary"
+                    class="btn btn-secondary btn-reset"
+                    data-role="reset-btn"
+                    title="Replace the buffer with the starter snippet"
+                >
+                    Reset
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-secondary actions-cluster-start"
                     data-role="vim-btn"
                     title="Toggle Vim keybindings"
                     aria-pressed="false"
                 >
                     Vim: off
-                </button>
-                <button
-                    type="button"
-                    class="btn btn-secondary"
-                    data-role="reset-btn"
-                    title="Replace the buffer with the starter snippet"
-                >
-                    Reset
                 </button>
                 <button
                     type="button"
@@ -321,41 +321,36 @@ endblock %} {% block content %}
         padding: 0;
     }
 
-    /* Make the editor fill the available vertical space by default,
-       not just in fullscreen mode. CodeMirror 6 doesn't react to a
-       flex-grown parent on its own; the simplest reliable knob is an
-       explicit height on `.cm-editor`. The scroller, content, and
-       gutters then need to be told to fill that height too, otherwise
-       only the content area is visually tall and the empty space
-       below the last line looks like dead padding. */
+    /* Give the editor a comfortable default size and let the rest of
+       the page (status row, output panel) flow naturally underneath
+       it. We intentionally avoid pinning the editor to the viewport
+       height: that broke fullscreen (the !important leaked in and
+       overlapped the output) and made the output panel feel detached
+       from the editor in the normal layout. */
     .exercise-section[data-step-id="playground"] .cm-editor {
-        height: calc(100vh - 18rem) !important;
-        min-height: 24rem;
+        min-height: 28rem;
     }
-    .exercise-section[data-step-id="playground"] .cm-scroller {
-        overflow: auto;
-        height: 100% !important;
-    }
-    .exercise-section[data-step-id="playground"] .cm-content,
-    .exercise-section[data-step-id="playground"] .cm-gutters {
-        min-height: 100% !important;
-    }
-    /* The textarea fallback (before CodeMirror takes over) should
-       match so there's no layout jump on hydration. */
     .exercise-section[data-step-id="playground"] [data-role="editor-fallback"] {
-        min-height: calc(100vh - 18rem);
+        min-height: 28rem;
     }
 
-    /* Icon-only toolbar button: square, currentColor SVG inside.
-       Matches `.btn.btn-secondary` height so it lines up with Vim /
-       Reset / Format in the actions row. */
+    /* Visually separate the destructive Reset from the helpful
+       Vim/Format/Run cluster on its right. */
+    .exercise-actions .actions-cluster-start {
+        margin-left: 1.25rem;
+    }
+    .btn.btn-reset {
+        color: var(--color-text-muted);
+    }
+    .btn.btn-reset:hover {
+        color: var(--color-text);
+    }
+
+    /* Icon-only toolbar button: square, same height as sibling `.btn`s
+       (2.25rem) so it lines up with Vim / Format / Run. */
     .btn.btn-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0.4rem;
-        width: 2rem;
-        height: 2rem;
+        width: 2.25rem;
+        padding: 0;
     }
     .btn.btn-icon svg {
         width: 1.05rem;
@@ -386,6 +381,7 @@ endblock %} {% block content %}
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        background: var(--color-background);
     }
     .exercise-section.is-fullscreen > div[style*="position: relative"] {
         flex: 1 1 auto;
@@ -401,6 +397,11 @@ endblock %} {% block content %}
     }
     .exercise-section.is-fullscreen .cm-editor {
         height: 100%;
+        min-height: 0;
+    }
+    .exercise-section.is-fullscreen .cm-scroller {
+        height: 100%;
+        overflow: auto;
     }
     .exercise-section.is-fullscreen [data-role="output-panel"] {
         flex: 0 0 auto;

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -312,34 +312,38 @@ endblock %} {% block content %}
         }
     }
 
-    /* Make the editor fill the available vertical space by default,
-       not just in fullscreen mode. The container and section both
-       become flex columns so the CodeMirror mount can stretch into
-       whatever's left below the intro prose and toolbar. */
-    body:has(.exercise-section[data-step-id="playground"]) .container {
-        display: flex;
-        flex-direction: column;
-    }
+    /* On the playground, strip the section card chrome (background,
+       border, padding) so the editor itself reads as the page's
+       primary canvas instead of a small panel nested inside one. */
     .exercise-section[data-step-id="playground"] {
-        display: flex;
-        flex-direction: column;
-        flex: 1 1 auto;
-        min-height: 0;
+        background: transparent;
+        border: 0;
+        padding: 0;
     }
-    .exercise-section[data-step-id="playground"]
-        > div[style*="position: relative"] {
-        flex: 1 1 auto;
-        min-height: 24rem;
-        display: flex;
-        flex-direction: column;
-    }
-    .exercise-section[data-step-id="playground"] [data-role="editor-mount"],
-    .exercise-section[data-step-id="playground"] [data-role="editor-fallback"] {
-        flex: 1 1 auto;
-        min-height: 24rem;
-    }
+
+    /* Make the editor fill the available vertical space by default,
+       not just in fullscreen mode. CodeMirror 6 doesn't react to a
+       flex-grown parent on its own; the simplest reliable knob is an
+       explicit height on `.cm-editor`. The scroller, content, and
+       gutters then need to be told to fill that height too, otherwise
+       only the content area is visually tall and the empty space
+       below the last line looks like dead padding. */
     .exercise-section[data-step-id="playground"] .cm-editor {
-        height: 100%;
+        height: calc(100vh - 18rem) !important;
+        min-height: 24rem;
+    }
+    .exercise-section[data-step-id="playground"] .cm-scroller {
+        overflow: auto;
+        height: 100% !important;
+    }
+    .exercise-section[data-step-id="playground"] .cm-content,
+    .exercise-section[data-step-id="playground"] .cm-gutters {
+        min-height: 100% !important;
+    }
+    /* The textarea fallback (before CodeMirror takes over) should
+       match so there's no layout jump on hydration. */
+    .exercise-section[data-step-id="playground"] [data-role="editor-fallback"] {
+        min-height: calc(100vh - 18rem);
     }
 
     /* Icon-only toolbar button: square, currentColor SVG inside.

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -16,9 +16,10 @@ endblock %} {% block content %}
             Press <strong>Run</strong> to compile and execute on
             <a href="https://play.rust-lang.org" target="_blank" rel="noopener"
                 >play.rust-lang.org</a
-            >. The <code>//!</code> at the top of the file is just a
-            doc-comment; replace it with notes to yourself or delete it
-            entirely.
+            >. Unlike the exercise editors, the scratchpad runs your
+            <code>main()</code> directly, so <code>println!</code>,
+            <code>dbg!</code>, and compiler warnings all show up in the output
+            panel below.
         </p>
     </div>
 
@@ -38,6 +39,45 @@ endblock %} {% block content %}
                     class="action-status"
                     aria-live="polite"
                 ></span>
+                <button
+                    type="button"
+                    class="btn btn-secondary btn-icon"
+                    data-role="fullscreen-btn"
+                    title="Toggle fullscreen editor (Esc to exit)"
+                    aria-pressed="false"
+                    aria-label="Toggle fullscreen editor"
+                >
+                    <svg
+                        class="icon-fullscreen-enter"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                    >
+                        <path d="M4 9V4h5" />
+                        <path d="M20 9V4h-5" />
+                        <path d="M4 15v5h5" />
+                        <path d="M20 15v5h-5" />
+                    </svg>
+                    <svg
+                        class="icon-fullscreen-exit"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                    >
+                        <path d="M9 4v5H4" />
+                        <path d="M15 4v5h5" />
+                        <path d="M9 20v-5H4" />
+                        <path d="M15 20v-5h5" />
+                    </svg>
+                </button>
                 <button
                     type="button"
                     class="btn btn-secondary"
@@ -169,12 +209,45 @@ endblock %} {% block content %}
                     copyButton: false,
                     urlPlugin: false,
                     syntaxHighlightOutput: false,
+                    runWithoutTests: true,
                 },
             });
         })
         .catch((err) => {
             console.error("inline-editor module failed to load:", err);
         });
+
+    // Fullscreen toggle. Pure CSS class swap on the section (no
+    // Fullscreen API): more predictable, doesn't fight the browser's
+    // own keyboard handling, and survives an unintended reload because
+    // the CodeMirror mount stays where it is in the DOM.
+    (function wireFullscreen() {
+        const section = document.querySelector(
+            '.exercise-section[data-step-id="playground"]',
+        );
+        const btn =
+            section && section.querySelector('[data-role="fullscreen-btn"]');
+        if (!section || !btn) return;
+        const setState = (on) => {
+            section.classList.toggle("is-fullscreen", on);
+            document.body.classList.toggle("playground-fullscreen", on);
+            btn.setAttribute("aria-pressed", on ? "true" : "false");
+            btn.title = on
+                ? "Exit fullscreen (Esc)"
+                : "Toggle fullscreen editor (Esc to exit)";
+        };
+        btn.addEventListener("click", () =>
+            setState(!section.classList.contains("is-fullscreen")),
+        );
+        document.addEventListener("keydown", (e) => {
+            if (
+                e.key === "Escape" &&
+                section.classList.contains("is-fullscreen")
+            ) {
+                setState(false);
+            }
+        });
+    })();
 </script>
 
 <style>
@@ -237,6 +310,75 @@ endblock %} {% block content %}
         to {
             transform: rotate(360deg);
         }
+    }
+
+    /* Icon-only toolbar button: square, currentColor SVG inside.
+       Matches `.btn.btn-secondary` height so it lines up with Vim /
+       Reset / Format in the actions row. */
+    .btn.btn-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.4rem;
+        width: 2rem;
+        height: 2rem;
+    }
+    .btn.btn-icon svg {
+        width: 1.05rem;
+        height: 1.05rem;
+    }
+    .btn.btn-icon .icon-fullscreen-exit {
+        display: none;
+    }
+    .exercise-section.is-fullscreen .btn.btn-icon .icon-fullscreen-enter {
+        display: none;
+    }
+    .exercise-section.is-fullscreen .btn.btn-icon .icon-fullscreen-exit {
+        display: inline;
+    }
+
+    /* Fullscreen mode: pin the section to the viewport and let the
+       CodeMirror mount stretch into the remaining vertical space.
+       `body.playground-fullscreen` hides the topbar so the editor
+       really fills the window. */
+    .exercise-section.is-fullscreen {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+        margin: 0;
+        border-radius: 0;
+        border: 0;
+        padding: 1rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+    .exercise-section.is-fullscreen > div[style*="position: relative"] {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .exercise-section.is-fullscreen [data-role="editor-mount"],
+    .exercise-section.is-fullscreen [data-role="editor-fallback"] {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: 100%;
+    }
+    .exercise-section.is-fullscreen .cm-editor {
+        height: 100%;
+    }
+    .exercise-section.is-fullscreen [data-role="output-panel"] {
+        flex: 0 0 auto;
+        max-height: 30vh;
+        overflow: auto;
+    }
+    body.playground-fullscreen {
+        overflow: hidden;
+    }
+    body.playground-fullscreen .topbar,
+    body.playground-fullscreen header.topbar {
+        display: none;
     }
 </style>
 {% endblock %}

--- a/templates/playground.html
+++ b/templates/playground.html
@@ -312,6 +312,36 @@ endblock %} {% block content %}
         }
     }
 
+    /* Make the editor fill the available vertical space by default,
+       not just in fullscreen mode. The container and section both
+       become flex columns so the CodeMirror mount can stretch into
+       whatever's left below the intro prose and toolbar. */
+    body:has(.exercise-section[data-step-id="playground"]) .container {
+        display: flex;
+        flex-direction: column;
+    }
+    .exercise-section[data-step-id="playground"] {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+    .exercise-section[data-step-id="playground"]
+        > div[style*="position: relative"] {
+        flex: 1 1 auto;
+        min-height: 24rem;
+        display: flex;
+        flex-direction: column;
+    }
+    .exercise-section[data-step-id="playground"] [data-role="editor-mount"],
+    .exercise-section[data-step-id="playground"] [data-role="editor-fallback"] {
+        flex: 1 1 auto;
+        min-height: 24rem;
+    }
+    .exercise-section[data-step-id="playground"] .cm-editor {
+        height: 100%;
+    }
+
     /* Icon-only toolbar button: square, currentColor SVG inside.
        Matches `.btn.btn-secondary` height so it lines up with Vim /
        Reset / Format in the actions row. */


### PR DESCRIPTION
Addresses two items from #7's Playground section:

- **"Playground: kein output (`dbg!()`, `println!()`)"**
- **"Playground: 'variable not used' wie kann ich die jetzt angucken?"**

### Root cause

`/api/run` always forwarded `tests: true` to play.rust-lang.org. With `tests: true` the Playground compiles the snippet with `--tests` and runs `cargo test`, which means the scratchpad's `fn main()` never executes — so `println!` / `dbg!` calls inside it produce no visible output, and `unused variable` warnings get buried in the test-runner framing.

### Fix

- **`src/bin/server.rs`**: `RunRequest` grows an optional `tests: bool` field (default `true`, so every exercise editor is unchanged). The handler forwards whatever the client sends.
- **`static/js/inline-editor.js`**: new `features.runWithoutTests` flag flips the request body to `tests: false` and adjusts the post-run status copy ("Ran." instead of the misleading "Compiled. No tests ran.").
- **`templates/playground.html`**: opts into the new flag, refreshes the intro copy, and adds an **icon-only fullscreen toggle** in the actions row. Click pins the section to the viewport, hides the topbar, and stretches the CodeMirror mount to fill the remaining space; click again or press Escape to exit. The icon is a four-corner-arrows SVG that swaps to its inverse when active.

### Validated locally

`cargo build --bin server` clean.

Curl roundtrip with `tests: false`:

```
POST /api/run {"code":"fn main(){ let x = 42; println!(\"done\"); }", "tests": false}
→ stdout: 'done\n'
→ stderr: 'warning: unused variable: `x`\n  --> src/main.rs:1:16\n  | help: prefix with _x ...'
```

Both lines now show up in the output panel via the existing `stdout + stderr` renderer.

Curl roundtrip without `tests` field (the path every exercise editor takes):

```
POST /api/run {"code":"fn main(){ println!(\"hi\"); }"}
→ stdout: '\nrunning 0 tests\n\ntest result: ok. ...'
```

Identical to pre-PR behaviour: exercises continue to compile in test mode.