### PR TITLE
5_count_file_lines: fixed test

### DIFF
--- a/examples/18_question_mark_operator/3_count_file_lines.rs
+++ b/examples/18_question_mark_operator/3_count_file_lines.rs
@@ -7,10 +7,7 @@ fn count_file_lines(filename: &str) -> Result<usize, std::io::Error> {
 fn test_count_file_lines() {
     use std::fs;
     fs::write("test.txt", "line 1\nline 2").unwrap();
-    // Once `count_file_lines` returns `Ok(2)`, this assertion succeeds:
-    // a `Result<T, E>` compares equal to `Ok(value)` via its derived
-    // `PartialEq`. No change needed below; fix `count_file_lines` above.
-    assert_eq!(count_file_lines("test.txt"), Ok(2));
+    assert_eq!(count_file_lines("test.txt").unwrap(), 2);
     assert!(count_file_lines("missing.txt").is_err());
     fs::remove_file("test.txt").ok();
 }


### PR DESCRIPTION
When submitting a valid implementation like:
```
// Reads a file and counts lines. Note how `?` works with a different error type.
fn count_file_lines(filename: &str) -> Result<usize, std::io::Error> {
    Ok(std::fs::read_to_string(filename)?.lines().count())
}
```

the test was still failing with an obscure error message about PartialEq:
```
   Compiling playground v0.0.1 (/playground)
error[E0369]: binary operation `==` cannot be applied to type `Result<usize, std::io::Error>`
  --> src/main.rs:13:5
   |
13 |     assert_eq!(count_file_lines("test.txt"), Ok(2));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     Result<usize, std::io::Error>
   |     Result<usize, std::io::Error>
   |
note: `std::io::Error` does not implement `PartialEq`
  --> /playground/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/error.rs:72:1
   |
72 | pub struct Error {
   | ^^^^^^^^^^^^^^^^ `std::io::Error` is defined in another crate

For more information about this error, try `rustc --explain E0369`.
error: could not compile `playground` (bin "playground" test) due to 1 previous error
```

This change should unblock less experienced learners