### PR TITLE
Add GitHub Actions CI (fmt, clippy, build, test, examples, spell + link check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: [main, live]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Formatting, linting, the binary build, unit tests, and the exercise
+  # check all share the same compiled dependency cache, so they live in
+  # one job to avoid recompiling axum/sqlx five times over.
+  rust:
+    name: rustfmt, clippy, build, test, examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+
+      # Cheapest check first: only reads the committed source. The
+      # `build.rs`-generated chapter `main.rs` files are committed and
+      # must stay rustfmt-clean.
+      - name: Formatting (cargo fmt --check)
+        run: cargo fmt --all --check
+
+      # Lint the library and binaries. The exercise examples are linted
+      # separately by scripts/check-examples.sh (some intentionally do
+      # not compile).
+      - name: Clippy (library + binaries)
+        run: cargo clippy --locked --lib --bins -- -D warnings
+
+      - name: Build binaries (cli + server)
+        run: cargo build --locked --bins
+
+      - name: Unit tests (library + binaries)
+        run: cargo test --locked --lib --bins
+
+      # Verify every exercise chapter compiles and lints clean, except the
+      # handful of deliberately-broken teaching chapters, which must still
+      # fail to compile.
+      - name: Verify exercises
+        run: ./scripts/check-examples.sh
+
+  spellcheck:
+    name: Spell check (typos)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run typos
+        uses: crate-ci/typos@master
+
+  link-check:
+    name: Link check (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Persist lychee's response cache between runs so unchanged links
+      # aren't re-fetched on every push.
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --root-dir .
+            --config ./lychee.toml
+            --no-progress
+            README.md
+            docs
+            examples
+            static/cheatsheet.md
+          fail: true

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 
+# lychee link-checker cache
+.lycheecache
+
 TODO/
 .screenshots/

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,21 @@
 # The course is a regular Cargo project, so every target here is a
 # thin wrapper. `make help` shows the full list.
 
-.PHONY: help dev run build test fmt clippy check clean
+.PHONY: help dev run build test fmt clippy check clean examples typos links ci fmt-check
 
 help:
-	@echo "make dev     - run the server with auto-reload (needs cargo-watch)"
-	@echo "make run     - run the server once"
-	@echo "make build   - cargo build"
-	@echo "make test    - cargo test"
-	@echo "make check   - cargo check"
-	@echo "make fmt     - cargo fmt"
-	@echo "make clippy  - cargo clippy"
-	@echo "make clean   - cargo clean"
+	@echo "make dev      - run the server with auto-reload (needs cargo-watch)"
+	@echo "make run      - run the server once"
+	@echo "make build    - cargo build"
+	@echo "make test     - cargo test (library + binaries)"
+	@echo "make check    - cargo check"
+	@echo "make fmt      - cargo fmt"
+	@echo "make clippy   - cargo clippy"
+	@echo "make examples - verify every exercise chapter (needs clippy)"
+	@echo "make typos    - spell check (needs typos-cli)"
+	@echo "make links    - link check (needs lychee)"
+	@echo "make ci       - run the full CI suite locally"
+	@echo "make clean    - cargo clean"
 
 # Rebuild + restart the server on every change. Install once with:
 #   cargo install cargo-watch
@@ -27,8 +31,11 @@ run:
 build:
 	cargo build
 
+# The exercise examples include deliberately-broken teaching files, so we
+# scope the default test/clippy targets to the library and binaries (CI
+# checks the examples separately via `make examples`).
 test:
-	cargo test
+	cargo test --lib --bins
 
 check:
 	cargo check
@@ -37,7 +44,26 @@ fmt:
 	cargo fmt
 
 clippy:
-	cargo clippy
+	cargo clippy --lib --bins -- -D warnings
+
+# Verify every exercise chapter is in its intended state (compiles + lints
+# clean, except the chapters that are meant to fail to compile).
+examples:
+	./scripts/check-examples.sh
+
+# Spell check. Install once with: cargo install typos-cli
+typos:
+	typos
+
+# Link check. Install once with: cargo install lychee
+links:
+	lychee --root-dir . --config ./lychee.toml README.md docs examples static/cheatsheet.md
+
+# Everything CI runs, in one shot.
+ci: fmt-check clippy build test examples typos links
+
+fmt-check:
+	cargo fmt --all --check
 
 clean:
 	cargo clean

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,26 @@
+# Configuration for the `typos` spell checker (https://github.com/crate-ci/typos).
+# Run locally with `typos` (install via `cargo install typos-cli`).
+
+[files]
+extend-exclude = [
+    # Vendored / minified third-party assets we don't control.
+    "static/js/htmx.min.js",
+    "*.min.js",
+    # Lock file: full of base32/hex hashes that look like typos.
+    "Cargo.lock",
+    # Local SQLite database artifacts.
+    "course.db",
+    "course.db-shm",
+    "course.db-wal",
+]
+
+[default]
+extend-ignore-re = [
+    # CSS `unicode-range` hex tokens, e.g. `U+02BA`, `U+1EF2-1EFF`.
+    "U\\+[0-9A-Fa-f?]+(-[0-9A-Fa-f?]+)?",
+]
+
+[default.extend-words]
+# "UPDATEs" in migration 008's comment gets camelCase-split into "UPDAT".
+# Migrations are checksum-locked once applied, so the file must not be edited.
+UPDAT = "UPDAT"

--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn process_chapter(dir: &Path) -> Result<(), String> {
          clippy::needless_pass_by_value,\n    \
          clippy::needless_pass_by_ref_mut,\n    \
          clippy::ptr_arg,\n    \
-         clippy::boxed_local,\n\
+         clippy::boxed_local\n\
          )]\n\n",
     );
     for (_n, path, module_name) in &step_files {

--- a/examples/00_integers/main.rs
+++ b/examples/00_integers/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_number_to_string.rs"]

--- a/examples/01_strings_and_chars/main.rs
+++ b/examples/01_strings_and_chars/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_welcome.rs"]

--- a/examples/02_conditionals_and_loops/main.rs
+++ b/examples/02_conditionals_and_loops/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_ferris_mood.rs"]

--- a/examples/03_functions/main.rs
+++ b/examples/03_functions/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_stray_semicolon.rs"]

--- a/examples/04_word_count/main.rs
+++ b/examples/04_word_count/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_word_count.rs"]

--- a/examples/05_enums_and_pattern_matching/main.rs
+++ b/examples/05_enums_and_pattern_matching/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_status_code.rs"]

--- a/examples/06_vectors/main.rs
+++ b/examples/06_vectors/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_count_items.rs"]

--- a/examples/07_hashmaps/main.rs
+++ b/examples/07_hashmaps/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_create_default_config.rs"]

--- a/examples/08_tuples_and_destructuring/main.rs
+++ b/examples/08_tuples_and_destructuring/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_get_user_info.rs"]

--- a/examples/09_option/main.rs
+++ b/examples/09_option/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_fallback.rs"]

--- a/examples/10_result/main.rs
+++ b/examples/10_result/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_safe_divide.rs"]

--- a/examples/11_ownership_and_borrowing/main.rs
+++ b/examples/11_ownership_and_borrowing/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_take_ownership.rs"]

--- a/examples/12_structs_and_methods/main.rs
+++ b/examples/12_structs_and_methods/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_new.rs"]

--- a/examples/13_traits/main.rs
+++ b/examples/13_traits/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_display_temperature.rs"]

--- a/examples/14_smart_pointers/main.rs
+++ b/examples/14_smart_pointers/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_boxed_sum.rs"]

--- a/examples/15_iterators/main.rs
+++ b/examples/15_iterators/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_sum.rs"]

--- a/examples/16_word_frequencies/main.rs
+++ b/examples/16_word_frequencies/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_count_words.rs"]

--- a/examples/17_password_validator/7_validate.md
+++ b/examples/17_password_validator/7_validate.md
@@ -27,7 +27,7 @@ Map the final score to `PasswordStrength`:
 - `>= 70` → `Strong`
 
 Push a short message into `feedback` for every rule that *fails*. That
-way [`PasswordAdvisor`](super) (or your own future code) has something
+way `PasswordAdvisor` (or your own future code) has something
 to react to. The length-related complaint should mention "characters",
 "length", "short", "longer", or "at least" so the test below can
 recognise it.

--- a/examples/17_password_validator/main.rs
+++ b/examples/17_password_validator/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_is_strong.rs"]

--- a/examples/18_question_mark_operator/main.rs
+++ b/examples/18_question_mark_operator/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_add_parsed_numbers.rs"]

--- a/examples/19_modules_and_visibility/main.rs
+++ b/examples/19_modules_and_visibility/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_calculate.rs"]

--- a/examples/20_environment_file_parser/main.rs
+++ b/examples/20_environment_file_parser/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "2_parse_line.rs"]

--- a/examples/21_csv_parser/main.rs
+++ b/examples/21_csv_parser/main.rs
@@ -9,7 +9,7 @@
     clippy::needless_pass_by_value,
     clippy::needless_pass_by_ref_mut,
     clippy::ptr_arg,
-    clippy::boxed_local,
+    clippy::boxed_local
 )]
 
 #[path = "3_simple_line.rs"]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,32 @@
+# Configuration for the lychee link checker (https://lychee.cli.rs).
+# Used by the `link-check` CI job and runnable locally with:
+#   lychee --root-dir "$PWD" .
+
+# Be resilient to flaky networks and rate limiting (doc.rust-lang.org is
+# referenced ~200 times across the exercises).
+max_retries = 4
+retry_wait_time = 2
+max_concurrency = 8
+
+# Cache results between runs so CI only re-checks new or changed links.
+cache = true
+max_cache_age = "2d"
+
+# Treat rate-limited responses as success instead of failing the build.
+accept = ["200..=299", "429"]
+
+# Local server routes and dev URLs that can't be resolved as static files.
+exclude_loopback = true
+exclude = [
+    # `/cheatsheet` is a live server route (see `src/bin/server.rs`),
+    # not a file on disk, so it can't be resolved offline.
+    "/cheatsheet$",
+]
+
+# Don't descend into build output, vendored assets, or screenshots.
+exclude_path = [
+    "target",
+    "static/js",
+    ".screenshots",
+    ".corrode",
+]

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Verify every exercise chapter is in its intended state.
+#
+# The course ships exercises as `todo!()` stubs that must still *compile*
+# (and lint cleanly) even before a learner fills them in. A couple of
+# chapters are the exception: they contain deliberately-broken teaching
+# files (a stray semicolon, a privacy error) that are *supposed* to fail
+# to compile so the learner reads the compiler error and fixes it.
+#
+# This script clippy-checks each chapter and asserts the outcome:
+#   - normal chapters MUST compile and lint clean (`-D warnings`),
+#   - chapters in EXPECTED_BROKEN MUST fail to compile.
+#
+# If an EXPECTED_BROKEN chapter starts compiling, that's a signal someone
+# changed a teaching exercise; update the list below on purpose.
+#
+# Run locally from the repo root with:
+#   ./scripts/check-examples.sh
+
+set -uo pipefail
+
+# Chapters whose `--example` target intentionally does not compile.
+# Keyed by the chapter directory name (the cargo example target name).
+EXPECTED_BROKEN=(
+    "03_functions"               # 3_stray_semicolon.rs, 6_cap_at.rs
+    "19_modules_and_visibility"  # 3_calculate.rs (privacy error)
+)
+
+is_expected_broken() {
+    local name="$1"
+    for broken in "${EXPECTED_BROKEN[@]}"; do
+        [[ "$name" == "$broken" ]] && return 0
+    done
+    return 1
+}
+
+failures=0
+
+for dir in examples/*/; do
+    name="$(basename "$dir")"
+    # Only directories with a `main.rs` are cargo example targets.
+    [[ -f "${dir}main.rs" ]] || continue
+
+    if cargo clippy --quiet --example "$name" -- -D warnings >/tmp/check-example.log 2>&1; then
+        compiled=1
+    else
+        compiled=0
+    fi
+
+    if is_expected_broken "$name"; then
+        if [[ "$compiled" -eq 1 ]]; then
+            echo "UNEXPECTED PASS  $name (listed as a teaching example that should NOT compile)"
+            echo "                 -> if you fixed it on purpose, remove it from EXPECTED_BROKEN."
+            failures=$((failures + 1))
+        else
+            echo "OK (broken)      $name (fails to compile, as intended)"
+        fi
+    else
+        if [[ "$compiled" -eq 1 ]]; then
+            echo "OK               $name"
+        else
+            echo "FAIL             $name (expected to compile + lint clean)"
+            echo "----- clippy output -----"
+            cat /tmp/check-example.log
+            echo "-------------------------"
+            failures=$((failures + 1))
+        fi
+    fi
+done
+
+if [[ "$failures" -ne 0 ]]; then
+    echo
+    echo "check-examples: $failures chapter(s) not in their expected state."
+    exit 1
+fi
+
+echo
+echo "check-examples: all chapters in their expected state."

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -525,7 +525,7 @@ fn extract_submission_target(file_path: &str) -> Result<SubmissionTarget> {
             .and_then(|s| s.to_str())
         {
             // Verify the stem starts with `<n>_` so we don't
-            // mis-classify a bare `examples/foo.rs`.
+            // misclassify a bare `examples/foo.rs`.
             if let Some((num, _rest)) = stem.split_once('_')
                 && num.parse::<u32>().is_ok()
             {


### PR DESCRIPTION
## What

Adds CI/CD via GitHub Actions, plus the tooling and small fixes needed for every check to pass.

### Workflow (`.github/workflows/ci.yml`)
Runs on pushes to `main`/`live` and on all PRs. Three jobs:

- **rust** (single job, shared compile cache):
  - `cargo fmt --all --check`
  - `cargo clippy --locked --lib --bins -- -D warnings`
  - `cargo build --locked --bins` (cli + server)
  - `cargo test --locked --lib --bins`
  - `./scripts/check-examples.sh`
- **spellcheck** — `crate-ci/typos`
- **link-check** — `lycheeverse/lychee-action` (with response cache)

### Exercise verification (`scripts/check-examples.sh`)
Compiles and lints every chapter with `-D warnings`. Normal chapters must
compile clean; the deliberately-broken teaching chapters (`03_functions`,
`19_modules_and_visibility`) are asserted to *still fail* to compile, so a
green CI also guards against someone accidentally "fixing" them.

### Configs
- `_typos.toml` — excludes vendored/minified JS, lockfile, CSS `unicode-range`
  hex, and a checksum-locked migration comment.
- `lychee.toml` — retries/cache, accepts 429, excludes the `/cheatsheet`
  runtime route (not a static file).
- `Makefile` — new `examples`, `typos`, `links`, and `ci` targets.

## Fixes required to make checks pass
- **`build.rs`**: the generated chapter `main.rs` allow-lists had a trailing
  comma rustfmt rejects, so `cargo fmt --check` failed on all 22. Removed it
  and regenerated the aggregators.
- **`src/bin/cli.rs`**: reworded a comment (`mis-classify` -> `misclassify`),
  the only real spell-check hit.
- **`examples/17_password_validator/7_validate.md`**: removed a malformed
  `(super)` link.
- **`.gitignore`**: ignore lychee's `.lycheecache`.

## Verified locally
fmt, clippy, build, test (8 passed), `check-examples.sh`, `typos`, and
`lychee` (207 OK / 0 errors online) all green.

## Note on "solutions"
Exercises ship as `todo!()` stubs whose correctness is defined by their own
`#[test]` blocks; there are no separate reference-solution files in the repo.
CI therefore verifies that every chapter compiles + lints in its intended
state, but can't run the exercise tests to green. If solutions live elsewhere
(a branch/generator), happy to add a job that fills them in and runs
`cargo test --examples`.