### PR TITLE
Restructure prep: versioning footer + writing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ dozen exercises you start to get the hang of it.
 This is an official course repository by [corrode](https://corrode.dev), a Rust
 consultancy that helps teams adopt Rust in production.
 
+> [!NOTE]
+> **The course is being restructured.** Active work happens on `main` and may be
+> mid-rewrite (chapters reordered, renumbered, or in flux). The **stable version
+> is [`v1`](https://github.com/corrode/course/tree/v1)** — use that if you want a
+> coherent run through the course. The live site runs the stable version; `main`
+> is for the restructure.
+
 ## How it works
 
 The course runs primarily through the website, which walks you through

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,8 @@ fn main() {
     println!("cargo:rerun-if-changed=examples");
     println!("cargo:rerun-if-changed=build.rs");
 
+    emit_git_build_info();
+
     let examples = Path::new("examples");
     if !examples.exists() {
         return;
@@ -55,6 +57,29 @@ fn main() {
             println!("cargo:warning=build.rs: skipping {}: {e}", path.display());
         }
     }
+}
+
+/// Emit `GIT_BRANCH` / `GIT_HASH` as compile-time env vars for the server footer.
+///
+/// Best-effort: if `git` isn't on PATH or `.git` isn't present (e.g. a Docker
+/// build from a tarball), we emit `unknown` and move on. `cargo:rerun-if-changed`
+/// on `.git/HEAD` refreshes the values when the checked-out commit/branch changes.
+fn emit_git_build_info() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git = |args: &[&str]| -> Option<String> {
+        let out = std::process::Command::new("git").args(args).output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() { None } else { Some(s) }
+    };
+
+    let branch = git(&["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    let hash = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
+    println!("cargo:rustc-env=GIT_HASH={hash}");
 }
 
 fn process_chapter(dir: &Path) -> Result<(), String> {

--- a/docs/writing-guidelines.md
+++ b/docs/writing-guidelines.md
@@ -1,0 +1,75 @@
+# Writing Guidelines
+
+The house style for chapter prose and exercise doc-comments. The goal is a course
+that respects the reader's time and existing experience. These rules exist to keep
+20+ chapters consistent as we restructure; apply them to every chapter you touch.
+
+## 1. Lead with the surprise (top principle)
+
+For every topic, open with the angle that **differs from other languages**, the
+**bug Rust prevents** at compile/runtime that would have shipped elsewhere, or the
+way it **hands power back to the programmer**. Never spend the reader's attention
+explaining what they already know; spend it on what makes Rust feel different and
+worth it.
+
+Per-chapter prompt: *"What's the empowering / bug-preventing Rust angle here?"*
+
+- `Option` → no null, no NullPointerException
+- `Result` → errors you can't forget to handle
+- ownership → memory safety without a garbage collector
+- enums → make illegal states unrepresentable
+- iterators → no off-by-one, no manual bounds checks
+- integers → overflow caught instead of silently wrapping
+
+Where it fits, go **problem-first**: show the bug that would compile-and-crash in
+many other languages (kept language-neutral — *"in most languages this throws at
+runtime"*), then show Rust's fix. (A per-language interactive comparison is a
+future idea, not something to author by hand now.)
+
+## 2. Audience axiom
+
+The reader already knows at least one other language. **Never explain what a
+variable, loop, function, return value, boolean, or integer _is_.** Do explain
+Rust-specific intuition, the *why*, and the gotchas a newcomer to Rust (not to
+programming) will hit.
+
+## 3. Voice
+
+Peer-to-peer, warm, dry wit allowed. Write like a competent colleague pairing with
+you, not a teacher addressing a class.
+
+**Banned tics** (cut on sight):
+
+- emoji-laden self-deprecation (e.g. "😬👉👈")
+- "how exciting", "your first exercise"
+- "the lightbulb moment", "the elephant in the room"
+- "you might not have noticed, but…"
+- any sentence that narrates the reader's emotional state *for* them
+
+Dry epigraph jokes (like the integers chapter's "it's pointless") are fine — that's
+wit, not condescension. The line is: joke *with* the reader, never *at* them, and
+never about how they're supposed to feel.
+
+## 4. Density guard
+
+Cutting a sentence that explains the obvious is good. Compressing two clear
+sentences into one dense one is not. **Cut, don't crush.** Removing condescension
+should make the prose lighter, not denser.
+
+## 5. Cross-references
+
+Refer to chapters by **name** ("the borrowing chapter", "the `Result` chapter"),
+not by number, so renumbering doesn't rot the prose.
+
+## 6. Pacing floor
+
+Don't shrink a core chapter below ~2 hands-on exercises — it should feel like
+practice, not a reading. (Pure "why" chapters like the ownership consolidation and
+the appendix are exempt.)
+
+## 7. Difficulty honesty
+
+When a concept is genuinely hard (the borrow checker, the `?`/error-type story, the
+CSV state machine), say so in a short, reassuring inline note: *"This is a known
+hard spot — if it takes a few tries, that's the concept being hard, not you."*
+Normalize the struggle instead of pretending everything is easy.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -27,6 +27,20 @@ use ulid::Ulid;
 /// Surfaced in the site footer so users can tell which release they're on.
 const COURSE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Git branch and short commit the running server was built from, injected by
+/// `build.rs` via `cargo:rustc-env`. `option_env!` keeps the build working when
+/// `.git` isn't available (e.g. some Docker builds); we fall back to "unknown".
+/// Surfaced next to `COURSE_VERSION` in the footer so we can tell which branch
+/// and commit a given deploy is on during the restructure.
+const GIT_BRANCH: &str = match option_env!("GIT_BRANCH") {
+    Some(b) => b,
+    None => "unknown",
+};
+const GIT_HASH: &str = match option_env!("GIT_HASH") {
+    Some(h) => h,
+    None => "unknown",
+};
+
 /// Application state shared across all routes
 #[derive(Clone)]
 struct AppState {

--- a/templates/base.html
+++ b/templates/base.html
@@ -2366,6 +2366,7 @@
                             rel="noopener"
                             >v{{ crate::COURSE_VERSION }}</a
                         >
+                        &middot; {{ crate::GIT_BRANCH }} @ {{ crate::GIT_HASH }}
                     </p>
                 </div>
 


### PR DESCRIPTION
First foundation PR for the course restructure (see `TODO/refactor-plan.md`, PRs A + B).

## PR A — Versioning footer
- `build.rs` emits `GIT_BRANCH` / `GIT_HASH` via `cargo:rustc-env` (best-effort; falls back to `unknown` when `.git` is absent, e.g. some Docker builds).
- `src/bin/server.rs` exposes them as consts next to `COURSE_VERSION`.
- Footer now renders `Version vX.Y.Z · <branch> @ <hash>` so we can tell which branch/commit a deploy is on during the restructure.
- `README.md` gains a restructure banner pointing at the stable `v1` branch.

## PR B — Writing guidelines
- `docs/writing-guidelines.md`: the house-style rubric. Top principle is **lead with the surprise** (motivation/bug-prevention first), plus the audience axiom, banned tics, density guard, name-based cross-refs, pacing floor, and difficulty honesty.

## Operational (done outside this PR)
- `v1` branch cut from the canonical `origin/main` stable commit and pushed.

## Still needs a human
- Point production deploy at `live` (stable) for the duration of the restructure.
- If Docker images build without `.git`, pass `--build-arg GIT_HASH=… GIT_BRANCH=…` or accept the `unknown` fallback.

CI: `fmt --check`, `clippy -D warnings`, and `cargo build --bins` all pass locally.