### PR TITLE
ci: build the Docker image on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,25 @@ jobs:
             examples
             static/cheatsheet.md
           fail: true
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the runtime image so a broken Dockerfile fails CI instead of the
+      # next deploy. Build-only (no push); the `.git` directory is excluded by
+      # .dockerignore, so this also exercises the `unknown` git-info fallback in
+      # build.rs. Layer cache is persisted via the GitHub Actions cache backend.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: cargo-course:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
The Docker image was never built in CI, so a broken `Dockerfile` would only surface at deploy time. This adds a build-only `docker` job.

## What it does
- New `docker` job in `.github/workflows/ci.yml` using Buildx + `docker/build-push-action` with `push: false` (smoke test only, no registry push).
- GitHub Actions layer cache (`type=gha`) keeps reruns fast.

## Why now
`.dockerignore` excludes `.git/`, so the image build hits the `unknown` git-info fallback added to `build.rs` (PR #25). Building in CI exercises that path too, so the footer-version change can't silently break the image.

## Validation
- Workflow YAML parses (4 jobs: rust, spellcheck, link-check, docker).
- `docker buildx build --check .` passes locally (no Dockerfile warnings).
- Full image build left to CI (a release build of axum/sqlx is too slow to run inline here).