### PR TITLE
Bonus-chapter mechanism (hidden from nav + progress)

### DIFF
--- a/examples/13_traits/7_what_we_learned.md
+++ b/examples/13_traits/7_what_we_learned.md
@@ -34,8 +34,9 @@ trait object so a single slice could hold a mix of validation rules.
   multiple concrete types at once. Reach for them when you need
   heterogeneity.
 - `Box<dyn Trait>` solves the "trait objects have no known size"
-  problem so they can live in owning containers like `Vec`. That's
-  the headline of Chapter 15 on smart pointers.
+  problem so they can live in owning containers like `Vec`. That's the
+  headline of the optional **smart pointers** bonus chapter (`Box`,
+  `Rc`, `RefCell`) — dip into it whenever you want to go deeper.
 - Many stdlib traits you already use (`Iterator`, `From`, `Into`,
   `PartialEq`, ...) are just regular traits. Nothing magic. You can
   define your own or implement the standard ones for your own types.

--- a/examples/14_smart_pointers/.chapter.toml
+++ b/examples/14_smart_pointers/.chapter.toml
@@ -1,0 +1,5 @@
+# Smart pointers (Box/Rc/RefCell) are opt-in depth, not part of the core
+# spine. Marking the chapter `bonus` hides it from the table of contents
+# and chapter picker, drops it from progress totals, and skips it in the
+# next-chapter flow. It stays reachable by direct URL.
+bonus = true

--- a/examples/16_word_frequencies/6_what_we_learned.md
+++ b/examples/16_word_frequencies/6_what_we_learned.md
@@ -25,3 +25,12 @@ the map, and a few aggregations to compute summary stats.
 - Tuples like `(usize, usize, f64)` work for tiny ad-hoc returns,
   but a named struct (`TextStats { total, unique, avg_len }`) reads
   better at the call site as soon as a function takes off in scope.
+
+## An optional detour
+
+You now have every tool you need to build a small program from scratch:
+structs, enums, iterators, `Option`, `Result`, vectors, and strings.
+There's an optional **Creative Break** chapter — an open-ended password
+validator project rather than a guided lesson. It isn't part of the main
+sequence and nothing later depends on it, so take it whenever you want a
+change of pace, or skip straight ahead.

--- a/examples/17_password_validator/.chapter.toml
+++ b/examples/17_password_validator/.chapter.toml
@@ -1,0 +1,7 @@
+# The password validator is the optional "Creative Break" project: an
+# open-ended chapter rather than a focused lesson. Marking it `bonus`
+# hides it from the table of contents and chapter picker, drops it from
+# progress totals, and skips it in the next-chapter flow. It stays
+# reachable by direct URL and via the forward mention at the end of the
+# word-frequencies chapter.
+bonus = true

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -152,6 +152,9 @@ struct ProgressDot {
     /// `false` for notes-only chapters (the appendix). Used to skip
     /// them when building the "next chapter" CTA and progress totals.
     has_exercises: bool,
+    /// `true` for optional bonus chapters: hidden from the TOC/picker and
+    /// excluded from progress and the next-chapter flow.
+    is_bonus: bool,
 }
 
 /// Per-exercise progress used by the chapter list and current-status badge.
@@ -289,6 +292,8 @@ struct ExerciseProgress {
     /// can't be "completed". The dashboard skips them when choosing
     /// the next chapter to resume.
     has_exercises: bool,
+    /// `true` for optional bonus chapters (hidden from nav and progress).
+    is_bonus: bool,
 }
 
 /// Individual submission for an exercise
@@ -578,7 +583,7 @@ fn completable_total(state: &AppState) -> i64 {
         state
             .exercises
             .iter()
-            .filter(|e| !e.is_quiz() && !e.code_steps().is_empty())
+            .filter(|e| !e.is_quiz() && !e.is_bonus() && !e.code_steps().is_empty())
             .count(),
     )
     .unwrap_or(i64::MAX)
@@ -601,7 +606,7 @@ async fn build_participant_summary(
             Ok(exercises) => i64::try_from(
                 exercises
                     .iter()
-                    .filter(|e| !e.is_quiz && e.has_exercises && e.completed)
+                    .filter(|e| !e.is_quiz && e.has_exercises && !e.is_bonus && e.completed)
                     .count(),
             )
             .unwrap_or(i64::MAX),
@@ -897,6 +902,7 @@ fn dots_from_exercises(exercises: &[ExerciseProgress]) -> Vec<ProgressDot> {
             current: false,
             is_quiz: e.is_quiz,
             has_exercises: e.has_exercises,
+            is_bonus: e.is_bonus,
         })
         .collect()
 }
@@ -921,7 +927,7 @@ async fn anonymous_dashboard(
 
     let first = exercises
         .iter()
-        .find(|e| !e.is_quiz && e.has_exercises)
+        .find(|e| !e.is_quiz && e.has_exercises && !e.is_bonus)
         .or_else(|| exercises.first());
     let (next_slug, next_label, next_chapter_number, next_chapter_title) = first.map_or_else(
         || {
@@ -943,7 +949,7 @@ async fn anonymous_dashboard(
     );
     let progress_total = exercises
         .iter()
-        .filter(|e| !e.is_quiz && e.has_exercises)
+        .filter(|e| !e.is_quiz && e.has_exercises && !e.is_bonus)
         .count();
 
     let template = DashboardTemplate {
@@ -1143,7 +1149,7 @@ async fn participant_dashboard(
     // a graceful default.
     let first_unfinished = exercises
         .iter()
-        .find(|e| !e.completed && !e.is_quiz && e.has_exercises)
+        .find(|e| !e.completed && !e.is_quiz && e.has_exercises && !e.is_bonus)
         .or_else(|| exercises.first());
     let any_completed = exercises.iter().any(|e| e.completed);
     let (next_slug, next_label, next_chapter_number, next_chapter_title) = match first_unfinished {
@@ -1168,11 +1174,11 @@ async fn participant_dashboard(
     };
     let progress_total = exercises
         .iter()
-        .filter(|e| !e.is_quiz && e.has_exercises)
+        .filter(|e| !e.is_quiz && e.has_exercises && !e.is_bonus)
         .count();
     let progress_done = exercises
         .iter()
-        .filter(|e| !e.is_quiz && e.has_exercises && e.completed)
+        .filter(|e| !e.is_quiz && e.has_exercises && !e.is_bonus && e.completed)
         .count();
 
     let team_token = participant.parsed_team_token();
@@ -1327,6 +1333,7 @@ async fn render_exercise_page(
                 current: i == idx,
                 is_quiz: e.is_quiz(),
                 has_exercises: !e.code_steps().is_empty(),
+                is_bonus: e.is_bonus(),
             }
         })
         .collect();
@@ -1420,21 +1427,22 @@ async fn render_exercise_page(
         }
     }
 
-    // Next chapter for the bottom CTA: the first dot that comes after
-    // the current one. We don't skip quizzes or appendices here so the
-    // CTA always points to whatever the picker would show next.
-    let next_dot = dots.get(idx + 1).cloned();
+    // Next chapter for the bottom CTA: the first non-bonus dot after the
+    // current one. We don't skip quizzes or appendices (the picker shows
+    // them), but bonus chapters are hidden from the picker, so the CTA
+    // skips them too.
+    let next_dot = dots.iter().skip(idx + 1).find(|d| !d.is_bonus).cloned();
 
     // Progress: how many completable chapters has the participant
     // finished? Quizzes and notes-only chapters never "complete", so
     // they're excluded from both numerator and denominator.
     let progress_total = dots
         .iter()
-        .filter(|d| !d.is_quiz && d.has_exercises)
+        .filter(|d| !d.is_quiz && d.has_exercises && !d.is_bonus)
         .count();
     let progress_done = dots
         .iter()
-        .filter(|d| !d.is_quiz && d.has_exercises && d.completed)
+        .filter(|d| !d.is_quiz && d.has_exercises && !d.is_bonus && d.completed)
         .count();
 
     let template = ExerciseTemplate {
@@ -2859,6 +2867,7 @@ async fn get_exercise_progress<'a>(
             submissions: exercise_submissions,
             is_quiz,
             has_exercises: !code_steps.is_empty(),
+            is_bonus: ex.is_bonus(),
         });
     }
 

--- a/src/exercises.rs
+++ b/src/exercises.rs
@@ -309,17 +309,24 @@ pub struct ChapterDirectives {
     /// on. `None` / `Some(false)` is the default (no inline signup).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signup_on_pass: Option<bool>,
+    /// When `true`, this chapter is an optional "bonus": hidden from the
+    /// table of contents and the chapter picker, excluded from progress
+    /// totals and the next-chapter flow, and rendered without a number.
+    /// It stays reachable by direct URL. `None` / `Some(false)` is the
+    /// default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bonus: Option<bool>,
 }
 
 /// A single chapter, parsed from one `examples/NN_slug/` directory.
 #[derive(Debug, Clone)]
 pub struct Exercise {
     /// 1-based, human-facing chapter number used in headings, the TOC,
-    /// and the chapter picker. Derived from the directory prefix as
-    /// `prefix + 1`, so `00_integers` (the first chapter on disk) is
-    /// displayed as **Chapter 1**. The shift exists because the dashboard
-    /// landing experience is itself an unnumbered "Chapter 0" (the
-    /// `println!` warm-up), and the on-disk chapters pick up at 1.
+    /// and the chapter picker. Assigned in [`scan_dir`] as a running
+    /// ordinal over the non-bonus chapters in disk order, so the first
+    /// chapter is **1** and hiding a bonus chapter leaves no gap in the
+    /// sequence. Bonus chapters get `0`, which templates render as
+    /// "Bonus" instead of a number.
     pub number: u8,
     /// Slug without the numeric prefix, e.g. `integers` for `00_integers`.
     pub slug: String,
@@ -347,6 +354,15 @@ impl Exercise {
     #[must_use]
     pub fn is_quiz(&self) -> bool {
         self.slug.contains("quiz")
+    }
+
+    /// True for optional "bonus" chapters (`bonus = true` in
+    /// `.chapter.toml`). Bonus chapters are hidden from the TOC, the
+    /// chapter picker, progress totals, and the next-chapter flow, but
+    /// stay reachable by direct URL. See [`ChapterDirectives::bonus`].
+    #[must_use]
+    pub fn is_bonus(&self) -> bool {
+        self.directives.bonus.unwrap_or(false)
     }
 
     /// All code steps in render order. Useful for progress calculations.
@@ -545,6 +561,21 @@ pub fn scan_dir(dir: &Path) -> Result<Vec<Exercise>> {
             }
         }
     }
+
+    // Assign human-facing chapter numbers as a running ordinal over the
+    // non-bonus chapters (in disk order), so hiding a bonus chapter leaves
+    // no gap. Bonus chapters get `0`, which templates render as "Bonus".
+    // This overrides the provisional `prefix + 1` set in `parse_chapter`.
+    let mut display = 0u8;
+    for ex in &mut out {
+        if ex.is_bonus() {
+            ex.number = 0;
+        } else {
+            display += 1;
+            ex.number = display;
+        }
+    }
+
     Ok(out)
 }
 
@@ -1268,6 +1299,35 @@ mod tests {
                 || primary.starter_code.starts_with("use "),
             "starter code should begin with code, not blank lines: {:?}",
             &primary.starter_code[..40.min(primary.starter_code.len())]
+        );
+    }
+
+    #[test]
+    fn bonus_chapters_are_unnumbered_and_excluded_from_the_sequence() {
+        let exercises =
+            scan_dir(Path::new("examples")).expect("examples dir should exist when running tests");
+
+        // The two bonus chapters carry `bonus = true` in `.chapter.toml`.
+        for slug in ["smart_pointers", "password_validator"] {
+            let ex = exercises
+                .iter()
+                .find(|e| e.slug == slug)
+                .unwrap_or_else(|| panic!("expected chapter `{slug}` to be present"));
+            assert!(ex.is_bonus(), "`{slug}` should be a bonus chapter");
+            assert_eq!(ex.number, 0, "bonus chapter `{slug}` should be unnumbered");
+        }
+
+        // Non-bonus chapters get a gap-free 1..=N ordinal in disk order, so
+        // hiding a bonus chapter never leaves a hole in the numbering.
+        let numbered: Vec<u8> = exercises
+            .iter()
+            .filter(|e| !e.is_bonus())
+            .map(|e| e.number)
+            .collect();
+        let expected: Vec<u8> = (1..=u8::try_from(numbered.len()).unwrap()).collect();
+        assert_eq!(
+            numbered, expected,
+            "non-bonus chapters should be numbered 1..=N with no gaps"
         );
     }
 

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -15,8 +15,10 @@ with (u) %}
         data-chapter-picker-toggle
     >
         <span class="chapter-picker-label"
-            ><span class="chapter-picker-num">{{ exercise.number }}</span>{{
-            exercise.title }}</span
+            ><span class="chapter-picker-num"
+                >{% if exercise.is_bonus() %}★{% else %}{{ exercise.number }}{%
+                endif %}</span
+            >{{ exercise.title }}</span
         >
         <svg
             class="chapter-picker-chevron"
@@ -54,7 +56,7 @@ with (u) %}
             </button>
         </div>
         <ul class="chapter-picker-list">
-            {% for d in dots %}
+            {% for d in dots %}{% if !d.is_bonus %}
             <li>
                 <a
                     role="option"
@@ -96,7 +98,7 @@ with (u) %}
                     </span>
                 </a>
             </li>
-            {% endfor %}
+            {% endif %}{% endfor %}
         </ul>
     </div>
 </div>
@@ -120,7 +122,10 @@ block topbar_team_title %}{% match ulid %}{% when Some with (_u) %}Your team{%
 when None %}Join a team{% endmatch %}{% endblock %} {% block content %}
 <div class="container" data-corrode-config="{{ exercise.directives_json() }}">
     <div class="exercise-header">
-        <div class="chapter-eyebrow">Chapter {{ exercise.number }}</div>
+        <div class="chapter-eyebrow">
+            {% if exercise.is_bonus() %}Bonus chapter{% else %}Chapter {{
+            exercise.number }}{% endif %}
+        </div>
         <h1 class="exercise-title">{{ exercise.title }}</h1>
         {% match ulid %} {% when Some with (_u) %}
         <div class="exercise-meta" id="exercise-meta">

--- a/templates/partials/chapter_list.html
+++ b/templates/partials/chapter_list.html
@@ -12,7 +12,7 @@ template variables: - dots: Vec<ProgressDot>
                 aria-label="All exercises"
                 style="--chapter-rows: {{ (dots.len() + 1) / 2 }}"
             >
-                {% for d in dots %} {% if d.current %}
+                {% for d in dots %} {% if !d.is_bonus %} {% if d.current %}
                 <span
                     class="chapter-row current{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
                     id="current-chapter-row"
@@ -40,7 +40,7 @@ template variables: - dots: Vec<ProgressDot>
                     <span class="chapter-title">{{ d.title }}</span>
                     <span class="chapter-mark" aria-hidden="true"></span>
                 </a>
-                {% endmatch %} {% endif %} {% endfor %}
+                {% endmatch %} {% endif %} {% endif %} {% endfor %}
             </nav></span
         ></String
     ></ProgressDot


### PR DESCRIPTION
Plan PR C (see `TODO/refactor-plan.md`). Adds the capability to mark a chapter as an optional **bonus**.

## Behavior
A chapter with `bonus = true` in `.chapter.toml` is:
- **hidden** from the table of contents and the chapter picker
- **excluded** from progress totals and the next-chapter CTA (which now skips it)
- rendered **without a number** ("Bonus chapter" eyebrow + ★ badge)
- still **reachable** by direct URL

## How
- `ChapterDirectives.bonus` + `Exercise::is_bonus()`.
- Chapter display numbers are assigned in `scan_dir` as a running **ordinal over non-bonus chapters**, so hiding a bonus leaves **no gap**. Bonus chapters get `0`. (Backward-compatible: with no bonus chapters the numbers are identical to the old `prefix + 1`.)
- `is_bonus` threaded through `ProgressDot`/`ExerciseProgress`; bonus excluded from `completable_total`, both dashboards, and the per-page progress + next-CTA.
- Templates: `chapter_list.html` and the `exercise.html` picker skip bonus rows; the header/label render "Bonus".
- Marked the two bonus chapters (`smart_pointers`, `password_validator`) via `.chapter.toml` **at their current locations** — PR D will relocate them.
- Forward mentions added to the word-frequencies and traits wrap-ups so the bonus chapters stay discoverable (also fixed a stale "Chapter 15" cross-ref).

## Validation
- New regression test `bonus_chapters_are_unnumbered_and_excluded_from_the_sequence` (numbers are 1..=N gap-free; bonus = 0).
- `fmt`, `clippy -D warnings`, lib+bin tests (15 pass), `check-examples.sh`, `REQUIRE_COMPLETE=1 check-solutions.sh` all green.
- **Runtime smoke test:** booted the server and confirmed bonus chapters are hidden from the homepage TOC + picker, the bonus page renders a "Bonus chapter" eyebrow, and the word-frequencies next-CTA skips the bonus chapter.

## Known pre-existing issue (not addressed here)
The dashboard TOC shows numbers one higher than exercise pages (`ExerciseProgress.number = ex.number + 1`). This predates the PR; I preserved it to keep scope tight. Worth a separate fix.