### PR TITLE
Numbers chapter: warmer prose + quick types tour, and codify the style

### DIFF
--- a/docs/writing-guidelines.md
+++ b/docs/writing-guidelines.md
@@ -22,7 +22,7 @@ Per-chapter prompt: *"What's the empowering / bug-preventing Rust angle here?"*
 - integers → overflow caught instead of silently wrapping
 
 Where it fits, go **problem-first**: show the bug that would compile-and-crash in
-many other languages (kept language-neutral — *"in most languages this throws at
+many other languages (kept language-neutral, *"in most languages this throws at
 runtime"*), then show Rust's fix. (A per-language interactive comparison is a
 future idea, not something to author by hand now.)
 
@@ -46,9 +46,18 @@ you, not a teacher addressing a class.
 - "you might not have noticed, but…"
 - any sentence that narrates the reader's emotional state *for* them
 
-Dry epigraph jokes (like the integers chapter's "it's pointless") are fine — that's
-wit, not condescension. The line is: joke *with* the reader, never *at* them, and
-never about how they're supposed to feel.
+Dry epigraph jokes (like the integers chapter's "it's pointless") are fine. That's
+wit, not condescension. Joke with the reader, never at them, and never about how
+they're supposed to feel.
+
+Write warm and human, the way you'd explain something to the person at the next
+desk. A few specifics that keep it that way:
+
+- No em-dashes. Use a period, a comma, or parentheses for an aside instead.
+- Go easy on colons. The "term: explanation" pattern, stacked sentence after
+  sentence, reads like clipped notes rather than writing. Prefer full sentences.
+- Keep it simple, not compressed. A slightly longer plain sentence beats a terse,
+  abbreviated one. Vary the length so it has a natural rhythm.
 
 ## 4. Density guard
 
@@ -63,13 +72,13 @@ not by number, so renumbering doesn't rot the prose.
 
 ## 6. Pacing floor
 
-Don't shrink a core chapter below ~2 hands-on exercises — it should feel like
+Don't shrink a core chapter below ~2 hands-on exercises. It should feel like
 practice, not a reading. (Pure "why" chapters like the ownership consolidation and
 the appendix are exempt.)
 
 ## 7. Difficulty honesty
 
 When a concept is genuinely hard (the borrow checker, the `?`/error-type story, the
-CSV state machine), say so in a short, reassuring inline note: *"This is a known
-hard spot — if it takes a few tries, that's the concept being hard, not you."*
-Normalize the struggle instead of pretending everything is easy.
+CSV state machine), say so in a short, reassuring inline note, e.g. *"This is a
+known hard spot. If it takes a few tries, that's the concept being hard, not
+you."* Normalize the struggle instead of pretending everything is easy.

--- a/examples/00_integers/1_intro.md
+++ b/examples/00_integers/1_intro.md
@@ -2,56 +2,66 @@
 
 *This chapter was supposed to start with an integer joke. Turns out, it's pointless.*
 
-Numbers feel familiar, so let's skip past what you already know and go straight
-to what Rust does differently.
-
-## Overflow is not silent
-
-Push a number past its type's maximum and most languages shrug: C wraps around,
-Java wraps around, Python silently grows the integer. Rust refuses. In a debug
-build, this **panics** instead of handing you a corrupted value:
+You already know how numbers work, so let's start with a quick tour of the types
+and then spend the rest of the chapter on what Rust does differently.
 
 ```rust
-let hp: u8 = 200;          // u8 holds 0–255
-let bonus: u8 = 100;
-let total = hp + bonus;    // panics: attempt to add with overflow
+let a: i32 = -42;             // signed 32-bit, the everyday default
+let b: u32 = 42;              // unsigned, so it can't go negative
+let big: i64 = 9_000_000_000; // 64-bit, for numbers too large for i32
+let i: usize = 0;             // the type for sizes and indices
+let byte: u8 = 255;           // a single byte, holds 0 to 255
+let price: f64 = 19.99;       // floating point (f32 is the smaller one)
 ```
 
-That's a whole class of bug — the silent wraparound that turns a 300-point
-health bar into 44 — caught before it can ship. When overflow is actually
-possible, you say what should happen instead of hoping:
+That covers almost everything you'll reach for. Now the parts that catch people
+out.
 
-- `a.saturating_add(b)` — clamp at the maximum (255 stays 255).
-- `a.checked_add(b)` — return `None` on overflow so you can handle it.
-- `a.wrapping_add(b)` — opt *in* to wraparound, for when you genuinely want it.
+## Overflow doesn't pass silently
+
+Push a number past its type's maximum and most languages just shrug. C wraps
+around, Java wraps around, Python quietly grows the integer to fit. Rust won't do
+that to you. In a debug build it stops and panics instead of handing back a wrong
+answer.
+
+```rust
+let hp: u8 = 200;       // a u8 holds 0 to 255
+let bonus: u8 = 100;
+let total = hp + bonus; // panics: attempt to add with overflow
+```
+
+The silent version of that bug is the one that quietly turns a 300-point health
+bar into 44 and ships to players. Rust catches it at the source instead. When a
+sum really might overflow, you tell Rust what you want to happen.
+
+- `a.saturating_add(b)` clamps at the maximum, so 255 stays 255.
+- `a.checked_add(b)` returns `None` on overflow, so you can handle it yourself.
+- `a.wrapping_add(b)` opts back into wraparound, for the times you actually want it.
 
 (Release builds wrap by default for speed, so don't lean on the panic in
-production — reach for these methods whenever overflow matters.)
+production. Reach for these methods whenever overflow matters.)
 
 ## No implicit conversions
 
-Rust never mixes numeric types for you. `u32 + i32` doesn't compile, and neither
-does multiplying a `u32` by an `f64`. You convert on purpose, with an `as` cast
-(which truncates) or `.into()` / `.try_into()` (checked):
+Rust never mixes numeric types for you. `u32 + i32` won't compile, and you can't
+multiply a `u32` by an `f64` either. You convert on purpose, either with an `as`
+cast that truncates, or with `.into()` and `.try_into()` when you want a checked
+conversion.
 
 ```rust
 let count: u32 = 42;
 let price: f64 = 19.99;
-let total = price * count as f64;   // explicit cast, no surprises
+let total = price * count as f64; // the cast is spelled out, so no surprises
 ```
-
-A quick reference for the types you'll meet: `i32` / `u32` (signed / unsigned
-32-bit, the everyday default), `usize` (sizes and indices), `u8` (a single
-byte), and `f32` / `f64` (floats). The `u` versions can't be negative.
 
 ## Text into numbers
 
-Parsing a string can fail — the input might not be a number at all — so `parse`
-hands back a `Result`:
+Parsing a string can fail, because the input might not be a number at all. So
+`parse` hands back a `Result`.
 
 ```rust
 let n: u32 = "123".parse().unwrap_or(0);
 ```
 
-`.unwrap_or(0)` is enough for now; the `Result` chapter shows the better way to
-handle the failure instead of papering over it.
+`.unwrap_or(0)` is fine for now. The `Result` chapter shows a better way to deal
+with the failure instead of papering over it.

--- a/examples/00_integers/3_add_health.md
+++ b/examples/00_integers/3_add_health.md
@@ -1,12 +1,12 @@
 # Health that doesn't wrap around
 
-A `u8` holds 0–255. Add past 255 and a debug build panics, while a release build
-wraps to a tiny number — so a fully-buffed character could read 3 HP instead of
-a capped 255. Neither is what you want from a health bar.
+A `u8` holds 0 to 255. Add past 255 and a debug build panics, while a release
+build wraps to a tiny number, so a fully-buffed character could read 3 HP instead
+of a capped 255. Neither is what you want from a health bar.
 
-`saturating_add` is the fix: it does the addition but clamps at the type's
-maximum instead of overflowing. Use it so stacking buffs tops out at 255 rather
-than wrapping around.
+`saturating_add` is the fix. It does the addition but clamps at the type's
+maximum instead of overflowing, so stacking buffs tops out at 255 rather than
+wrapping around.
 
 ## Useful from the standard library
 


### PR DESCRIPTION
Two things, both from style feedback:

## House style rule (docs/writing-guidelines.md)
Added a 'warm and human' rule to the Voice section: no em-dashes, go easy on colons (the 'term: explanation' pattern stacked over and over reads like clipped notes), and prefer full, simple sentences with natural rhythm. Also fixed the rubric's own em-dashes to match.

## Integers intro
- Rewrote it in that style (no em-dashes, fewer colons, warmer).
- Added a quick **integer-types tour** up front: a code block with one comment per type (i32, u32, i64, usize, u8, f64), as requested, before moving on to overflow / no-implicit-conversions / parse.
- Removed the 'a whole class of' filler and the en-dash range (now '0 to 255').

Markdown-only; build + typos clean. (Applies to the already-merged #28 intro.)