### PR TITLE
Fix off-by-one chapter number in the dashboard TOC

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -2858,7 +2858,7 @@ async fn get_exercise_progress<'a>(
         };
 
         exercises.push(ExerciseProgress {
-            number: ex.number + 1,
+            number: ex.number,
             name: ex.file_stem.clone(),
             completed,
             perfected,


### PR DESCRIPTION
The dashboard, admin, and team chapter lists were showing chapter numbers one higher than the exercise pages and the chapter picker.

The cause was in `get_exercise_progress`: it set `ExerciseProgress.number = ex.number + 1`. But `ex.number` is already the 1-based display number (assigned as a running ordinal in `scan_dir`), so the `+ 1` double-counted. The other code paths (`ProgressDot` in the picker and the exercise page) already use `ex.number` directly, which is why they disagreed.

Dropping the `+ 1` makes everything use the same number.

This is the small standalone fix that was noted but deferred during the bonus-chapter work (PR C). Branched off `main`, independent of the restructure PR. Build, clippy, and tests pass.
