### PR TITLE
Bake main as the default footer branch in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,11 @@ WORKDIR /app
 
 # Build-time git metadata for the footer. The build context excludes
 # `.git` (see .dockerignore), so `build.rs` can't shell out to git here.
-# The deploy passes these as build args instead; Coolify auto-injects
-# `SOURCE_COMMIT`. Set GIT_BRANCH as a build arg in Coolify (e.g. `main`).
-ARG GIT_BRANCH=unknown
+# Production only ever deploys `main`, so default the branch to `main`
+# (override with `--build-arg GIT_BRANCH=...` for a one-off branch build).
+# The commit comes from Coolify's auto-injected `SOURCE_COMMIT`; set
+# `GIT_HASH` explicitly to override it.
+ARG GIT_BRANCH=main
 ARG GIT_HASH=
 ARG SOURCE_COMMIT=
 ENV GIT_BRANCH=${GIT_BRANCH} \


### PR DESCRIPTION
Follow-up to the footer wiring. The previous version left GIT_BRANCH defaulting to "unknown" in the image unless you set a Coolify build arg.

Since prod only ever deploys main, this just defaults `ARG GIT_BRANCH=main` in the Dockerfile, so the branch is baked into every image with no Coolify config. It's still overridable with `--build-arg GIT_BRANCH=...` for a one-off branch build. The commit hash continues to come from Coolify's auto-injected `SOURCE_COMMIT` (no config needed).

Verified in a real docker build: passing `--build-arg GIT_BRANCH=dockerbranchtest --build-arg SOURCE_COMMIT=deadbeefcafe1234` bakes `dockerbranchtest` and `deadbee` into the server binary, so the footer reads `<branch> @ <hash>`.
