### PR TITLE
Resolve footer git commit at runtime (no more 'main @ unknown')

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,20 @@ FROM rust:1-trixie AS builder
 
 WORKDIR /app
 
-# Build-time git metadata for the footer. The build context excludes
-# `.git` (see .dockerignore), so `build.rs` can't shell out to git here.
-# Production only ever deploys `main`, so default the branch to `main`
-# (override with `--build-arg GIT_BRANCH=...` for a one-off branch build).
-# The commit comes from Coolify's auto-injected `SOURCE_COMMIT`; set
-# `GIT_HASH` explicitly to override it.
+# Build-time git metadata for the footer, used only as a fallback. The
+# build context excludes `.git` (see .dockerignore) so `build.rs` can't
+# shell out to git here, and since Coolify v450 `SOURCE_COMMIT` is no
+# longer injected as a build arg by default (it busts the layer cache).
+# The server therefore resolves the branch and commit from the *runtime*
+# environment first (Coolify exposes `SOURCE_COMMIT` and `COOLIFY_BRANCH`
+# to the container), falling back to these baked-in values. Production
+# only ever deploys `main`, so default the branch to `main`. Pass
+# `--build-arg GIT_HASH=...` (and/or `GIT_BRANCH=...`) to bake values in
+# for a one-off build outside Coolify.
 ARG GIT_BRANCH=main
 ARG GIT_HASH=
-ARG SOURCE_COMMIT=
 ENV GIT_BRANCH=${GIT_BRANCH} \
-    GIT_HASH=${GIT_HASH} \
-    SOURCE_COMMIT=${SOURCE_COMMIT}
+    GIT_HASH=${GIT_HASH}
 
 # Cache dependencies separately from source. Copy just the manifests
 # first, build a dummy main so cargo downloads + compiles deps, then

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::{Row, Sqlite, SqlitePool, migrate::MigrateDatabase, sqlite::SqlitePoolOptions};
 use std::env;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tower_http::services::ServeDir;
 use ulid::Ulid;
 
@@ -27,19 +27,58 @@ use ulid::Ulid;
 /// Surfaced in the site footer so users can tell which release they're on.
 const COURSE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Git branch and short commit the running server was built from, injected by
-/// `build.rs` via `cargo:rustc-env`. `option_env!` keeps the build working when
-/// `.git` isn't available (e.g. some Docker builds); we fall back to "unknown".
-/// Surfaced next to `COURSE_VERSION` in the footer so we can tell which branch
-/// and commit a given deploy is on during the restructure.
-const GIT_BRANCH: &str = match option_env!("GIT_BRANCH") {
-    Some(b) => b,
-    None => "unknown",
-};
-const GIT_HASH: &str = match option_env!("GIT_HASH") {
-    Some(h) => h,
-    None => "unknown",
-};
+/// Build-time git metadata baked in by `build.rs` via `cargo:rustc-env`.
+/// `option_env!` keeps the build working when `.git` isn't available (the
+/// Docker build context excludes it), in which case these are `None`.
+const GIT_BRANCH_BUILD: Option<&str> = option_env!("GIT_BRANCH");
+const GIT_HASH_BUILD: Option<&str> = option_env!("GIT_HASH");
+
+/// Git branch and short commit shown in the footer, resolved once at startup.
+///
+/// We prefer a runtime environment variable over the build-time value. The
+/// production deploy (Coolify) builds the image with `.git` excluded and, since
+/// Coolify v450, no longer injects `SOURCE_COMMIT` as a build arg by default
+/// (it would bust the Docker layer cache), so `build.rs` bakes in "unknown".
+/// Coolify still exposes the commit and branch to the running container as the
+/// env vars `SOURCE_COMMIT` and `COOLIFY_BRANCH`, so we read those at runtime.
+/// Precedence: explicit runtime override, then the build-time value, then
+/// "unknown".
+static GIT_BRANCH: LazyLock<String> = LazyLock::new(|| {
+    git_env("GIT_BRANCH")
+        .or_else(|| git_env("COOLIFY_BRANCH"))
+        .or_else(|| usable(GIT_BRANCH_BUILD.map(str::to_owned)))
+        .unwrap_or_else(|| "unknown".into())
+});
+
+static GIT_HASH: LazyLock<String> = LazyLock::new(|| {
+    git_env("GIT_HASH")
+        .or_else(|| git_env("SOURCE_COMMIT").map(|s| s.chars().take(7).collect()))
+        .or_else(|| usable(GIT_HASH_BUILD.map(str::to_owned)))
+        .unwrap_or_else(|| "unknown".into())
+});
+
+/// A runtime environment variable, normalised: trimmed, and treated as absent
+/// when empty or the literal "unknown".
+fn git_env(key: &str) -> Option<String> {
+    usable(std::env::var(key).ok())
+}
+
+/// Drop values that carry no information (empty or "unknown"), trim the rest.
+fn usable(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "unknown")
+}
+
+/// Footer accessors used by `base.html`. Askama can't render a `LazyLock`
+/// directly, so hand it a plain `&str`.
+fn git_branch() -> &'static str {
+    GIT_BRANCH.as_str()
+}
+
+fn git_hash() -> &'static str {
+    GIT_HASH.as_str()
+}
 
 /// Application state shared across all routes
 #[derive(Clone)]
@@ -3006,5 +3045,18 @@ mod tests {
     #[test]
     fn bucket_participants_handles_empty_input() {
         assert!(bucket_participants_by_team(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn usable_filters_out_uninformative_git_values() {
+        // Real values pass through, trimmed.
+        assert_eq!(usable(Some("main".into())), Some("main".into()));
+        assert_eq!(usable(Some("  abc1234 ".into())), Some("abc1234".into()));
+        // Absent, empty, whitespace-only, and the "unknown" sentinel all
+        // collapse to None so the next source in the chain is tried.
+        assert_eq!(usable(None), None);
+        assert_eq!(usable(Some(String::new())), None);
+        assert_eq!(usable(Some("   ".into())), None);
+        assert_eq!(usable(Some("unknown".into())), None);
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -2366,7 +2366,7 @@
                             rel="noopener"
                             >v{{ crate::COURSE_VERSION }}</a
                         >
-                        &middot; {{ crate::GIT_BRANCH }} @ {{ crate::GIT_HASH }}
+                        &middot; {{ crate::git_branch() }} @ {{ crate::git_hash() }}
                     </p>
                 </div>
 


### PR DESCRIPTION
## Problem

The site footer shows `Version v0.1.0 · main @ unknown`. The branch resolves (`main`), but the commit hash is `unknown`.

## Why

`GIT_BRANCH`/`GIT_HASH` were baked in at **compile time** by `build.rs`. In the production image that fails for the commit:

- The Docker build context excludes `.git` (`.dockerignore`), so `build.rs` can't shell out to git.
- Since **Coolify v450**, `SOURCE_COMMIT` is [no longer injected as a build arg by default](https://github.com/coollabsio/coolify/pull/7352) (it busted the Docker layer cache). So the build-time `SOURCE_COMMIT` is empty and the hash falls through to `unknown`.
- The branch still shows `main` only because the Dockerfile defaults `ARG GIT_BRANCH=main`.

Coolify *does* still expose `SOURCE_COMMIT` (and `COOLIFY_BRANCH`) to the **running container** as runtime env vars.

## Fix

Resolve the footer branch/commit at **runtime**, falling back to the build-time value, then `unknown`:

- `server.rs`: `GIT_BRANCH`/`GIT_HASH` become `LazyLock<String>` resolved once at startup.
  - branch: `GIT_BRANCH` env → `COOLIFY_BRANCH` env → build-time → `unknown`
  - commit: `GIT_HASH` env → `SOURCE_COMMIT` env (first 7 chars) → build-time → `unknown`
  - Empty and literal `unknown` values are treated as absent so the chain keeps looking.
- `base.html`: footer calls `crate::git_branch()` / `crate::git_hash()` instead of the old consts.
- `Dockerfile`: drop the now-unused `SOURCE_COMMIT` build arg and document the runtime-first behavior.

Local dev is unchanged: with `.git` present, `build.rs` still bakes in the real branch/commit, which the runtime fallback uses when no env vars are set.

## Validation

- `cargo test --locked --lib --bins` — 9 passed, including a new `usable_filters_out_uninformative_git_values` test for the normalizer (empty / whitespace / `unknown` → treated as absent).
- `cargo clippy --locked --lib --bins -- -D warnings` — clean (Askama compiles the template, so the new function calls are checked).
- `cargo fmt --all --check` — clean.

## Note

I went with runtime resolution rather than re-enabling Coolify's build-arg injection because that toggle lives in the Coolify UI (not the repo) and re-enabling it reintroduces the layer-cache busting that v450 fixed. Reading the runtime env keeps the image cacheable and works regardless of that setting.