### PR TITLE
Add "A Quick Tour of Rust" preamble page

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -97,6 +97,24 @@ struct PlaygroundTemplate {
     starter: String,
 }
 
+/// Template for the read-only "A Quick Tour of Rust" preamble page.
+/// Renders one editable, runnable code box (the Mario tour) with
+/// concept-class hover explanations.
+#[derive(Template)]
+#[template(path = "tour.html")]
+struct TourTemplate {
+    /// The annotated tour source shown in the editor.
+    starter: String,
+    /// Always `None`: the tour is anonymous preamble with no participant
+    /// context. Present so it can share `partials/next_chapter_cta.html`.
+    ulid: Option<String>,
+    /// The first real chapter, rendered as the closing "Next chapter"
+    /// CTA via the shared partial. `None` if the catalog is empty.
+    next_dot: Option<ProgressDot>,
+    /// Always `false`: the tour's CTA is never locked behind completion.
+    next_locked: bool,
+}
+
 /// Template for the cheatsheet page. Just renders pre-built HTML
 /// produced from `static/cheatsheet.md` at startup.
 #[derive(Template)]
@@ -118,6 +136,8 @@ struct ExerciseTemplate {
     /// One entry per exercise in the catalog, ordered by `number`.
     /// Used to render the bottom "chapter list" navigation.
     dots: Vec<ProgressDot>,
+    /// Rows in the first TOC column; see [`chapter_rows`].
+    chapter_rows: usize,
     /// Ordered render plan: prose blocks and code sections in display
     /// order. Each `Code` carries the per-step status and the database
     /// key (`<chapter>/<step_key>` or just `<chapter>` for legacy).
@@ -126,6 +146,11 @@ struct ExerciseTemplate {
     /// or `None` when this is the last chapter. Used for the
     /// "Next chapter" call-to-action at the bottom of the page.
     next_dot: Option<ProgressDot>,
+    /// When `true`, the next-chapter CTA renders hidden (`.is-locked`)
+    /// until the participant completes the current chapter. Always
+    /// `false` on the public route. Consumed by
+    /// `partials/next_chapter_cta.html`.
+    next_locked: bool,
     /// Number of completable chapters the participant has finished.
     /// Quizzes and notes-only chapters don't count toward either total.
     progress_done: usize,
@@ -155,6 +180,32 @@ struct ProgressDot {
     /// `true` for optional bonus chapters: hidden from the TOC/picker and
     /// excluded from progress and the next-chapter flow.
     is_bonus: bool,
+    /// Optional explicit link target. When `Some`, the TOC partial and
+    /// chapter picker link straight here instead of deriving an
+    /// `/exercise/{slug}` URL. Used for non-exercise entries like the
+    /// read-only "Quick Tour" preamble (`/tour`).
+    href: Option<String>,
+}
+
+/// Synthetic chapter-list entry for the read-only "A Quick Tour of
+/// Rust" preamble. It isn't a real exercise (no code steps, no tests,
+/// no progress), so it carries an explicit `/tour` href and
+/// `has_exercises = false` to stay out of the progress totals while
+/// still showing as the first row of the table of contents.
+fn tour_dot() -> ProgressDot {
+    ProgressDot {
+        slug: "tour".to_string(),
+        number: 0,
+        title: "A Quick Tour of Rust".to_string(),
+        attempted: false,
+        completed: false,
+        perfected: false,
+        current: false,
+        is_quiz: false,
+        has_exercises: false,
+        is_bonus: false,
+        href: Some("/tour".to_string()),
+    }
 }
 
 /// Per-exercise progress used by the chapter list and current-status badge.
@@ -191,6 +242,8 @@ struct DashboardTemplate {
     /// two stay visually identical. `current` is always `false`
     /// here because the homepage isn't any one chapter.
     dots: Vec<ProgressDot>,
+    /// Rows in the first TOC column; see [`chapter_rows`].
+    chapter_rows: usize,
     /// Slug of the first chapter the participant hasn't completed yet,
     /// or the first chapter overall if they're brand new / fully done.
     /// Used by the "Start" call-to-action.
@@ -815,6 +868,8 @@ async fn main() -> Result<()> {
         .route("/exercise/{slug}", get(public_exercise_page))
         .route("/exercise/{ulid}/{slug}", get(participant_exercise_page))
         .route("/playground", get(playground_page))
+        .route("/tour", get(tour_page))
+        .route("/tour/{ulid}", get(tour_page_with_ulid))
         .route("/settings", get(settings_page))
         .route("/settings/{ulid}", get(participant_settings_page))
         .route("/cheatsheet", get(cheatsheet_page))
@@ -890,9 +945,8 @@ async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
 /// so both pages feed the same `partials/chapter_list.html` partial.
 /// `current` is always `false` on the homepage.
 fn dots_from_exercises(exercises: &[ExerciseProgress]) -> Vec<ProgressDot> {
-    exercises
-        .iter()
-        .map(|e| ProgressDot {
+    std::iter::once(tour_dot())
+        .chain(exercises.iter().map(|e| ProgressDot {
             slug: e.name.clone(),
             number: e.number,
             title: e.title.clone(),
@@ -903,8 +957,19 @@ fn dots_from_exercises(exercises: &[ExerciseProgress]) -> Vec<ProgressDot> {
             is_quiz: e.is_quiz,
             has_exercises: e.has_exercises,
             is_bonus: e.is_bonus,
-        })
+            href: None,
+        }))
         .collect()
+}
+
+/// Number of rows in the first column of the two-column table of
+/// contents (`partials/chapter_list.html`). The list uses
+/// `grid-auto-flow: column` with `--chapter-rows` rows, filling the
+/// first column before the second, so this is `ceil(visible / 2)`.
+/// Counts only rendered (non-bonus) rows so the two columns stay
+/// balanced as chapters are added or removed.
+fn chapter_rows(dots: &[ProgressDot]) -> usize {
+    dots.iter().filter(|d| !d.is_bonus).count().div_ceil(2)
 }
 
 /// Anonymous dashboard at `/`.
@@ -952,10 +1017,12 @@ async fn anonymous_dashboard(
         .filter(|e| !e.is_quiz && e.has_exercises && !e.is_bonus)
         .count();
 
+    let dots = dots_from_exercises(&exercises);
     let template = DashboardTemplate {
         participant_name: None,
         ulid: None,
-        dots: dots_from_exercises(&exercises),
+        chapter_rows: chapter_rows(&dots),
+        dots,
         next_slug,
         next_label,
         next_chapter_number,
@@ -1011,6 +1078,64 @@ fn render_signup(team_slug: Option<String>) -> axum::response::Response {
         },
         |html| Html(html).into_response(),
     )
+}
+
+/// Read-only "A Quick Tour of Rust" preamble page at `/tour`.
+///
+/// Ships the annotated Mario tour source (embedded at compile time)
+/// into one editable, runnable code box. Like the playground, edits
+/// live in `localStorage` and "Run" proxies to play.rust-lang.org; the
+/// page adds concept-class hover explanations on top.
+async fn tour_page(State(state): State<AppState>) -> impl IntoResponse {
+    render_tour(&state, None)
+}
+
+/// Same tour page, but reached with a participant ULID (e.g. straight
+/// after signing up on the dashboard warm-up). The ULID is threaded
+/// into the closing "Next chapter" CTA so the learner keeps their
+/// progress context when they move on to chapter 1.
+async fn tour_page_with_ulid(
+    AxumPath(ulid): AxumPath<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    render_tour(&state, Some(ulid))
+}
+
+fn render_tour(state: &AppState, ulid: Option<String>) -> axum::response::Html<String> {
+    const STARTER: &str = include_str!("../../static/tour_starter.rs");
+    // Derive the first real chapter the same way the dashboard does, so
+    // the closing CTA keeps pointing at the right place even if chapters
+    // are renamed or reordered.
+    let first = state
+        .exercises
+        .iter()
+        .find(|e| !e.is_quiz() && !e.is_bonus() && !e.code_steps().is_empty());
+    let next_dot = first.map(|e| ProgressDot {
+        slug: e.slug.clone(),
+        number: e.number,
+        title: e.title.clone(),
+        attempted: false,
+        completed: false,
+        perfected: false,
+        current: false,
+        is_quiz: e.is_quiz(),
+        has_exercises: !e.code_steps().is_empty(),
+        is_bonus: e.is_bonus(),
+        href: None,
+    });
+    let template = TourTemplate {
+        starter: STARTER.to_string(),
+        ulid,
+        next_dot,
+        next_locked: false,
+    };
+    match template.render() {
+        Ok(html) => Html(html),
+        Err(e) => {
+            error!("tour template render failed: {e}");
+            Html("Error rendering template".to_string())
+        }
+    }
 }
 
 /// Standalone Rust scratchpad. Code is persisted client-side in
@@ -1182,10 +1307,12 @@ async fn participant_dashboard(
         .count();
 
     let team_token = participant.parsed_team_token();
+    let dots = dots_from_exercises(&exercises);
     let template = DashboardTemplate {
         participant_name: Some(participant.name),
         ulid: Some(ulid.clone()),
-        dots: dots_from_exercises(&exercises),
+        chapter_rows: chapter_rows(&dots),
+        dots,
         next_slug,
         next_label,
         next_chapter_number,
@@ -1314,11 +1441,8 @@ async fn render_exercise_page(
         .cloned()
         .unwrap_or_default();
 
-    let dots: Vec<ProgressDot> = state
-        .exercises
-        .iter()
-        .enumerate()
-        .map(|(i, e)| {
+    let dots: Vec<ProgressDot> = std::iter::once(tour_dot())
+        .chain(state.exercises.iter().enumerate().map(|(i, e)| {
             let s = chapter_progress
                 .get(&e.file_stem)
                 .cloned()
@@ -1334,8 +1458,9 @@ async fn render_exercise_page(
                 is_quiz: e.is_quiz(),
                 has_exercises: !e.code_steps().is_empty(),
                 is_bonus: e.is_bonus(),
+                href: None,
             }
-        })
+        }))
         .collect();
 
     // Build the ordered render plan from the chapter's steps.
@@ -1430,8 +1555,14 @@ async fn render_exercise_page(
     // Next chapter for the bottom CTA: the first non-bonus dot after the
     // current one. We don't skip quizzes or appendices (the picker shows
     // them), but bonus chapters are hidden from the picker, so the CTA
-    // skips them too.
-    let next_dot = dots.iter().skip(idx + 1).find(|d| !d.is_bonus).cloned();
+    // skips them too. Locate the current dot by its flag rather than by
+    // `idx`, since `dots` is prefixed with the synthetic tour entry.
+    let next_dot = dots
+        .iter()
+        .skip_while(|d| !d.current)
+        .skip(1)
+        .find(|d| !d.is_bonus)
+        .cloned();
 
     // Progress: how many completable chapters has the participant
     // finished? Quizzes and notes-only chapters never "complete", so
@@ -1445,13 +1576,16 @@ async fn render_exercise_page(
         .filter(|d| !d.is_quiz && d.has_exercises && !d.is_bonus && d.completed)
         .count();
 
+    let next_locked = ulid.is_some() && !current_status.completed;
     let template = ExerciseTemplate {
         exercise,
         ulid,
         current_status,
+        chapter_rows: chapter_rows(&dots),
         dots,
         items,
         next_dot,
+        next_locked,
         progress_done,
         progress_total,
     };

--- a/static/js/inline-editor.js
+++ b/static/js/inline-editor.js
@@ -527,6 +527,15 @@ export async function mountInlineEditor(section, opts = {}) {
       ...(urlPlugin ? [urlPlugin, urlTheme] : []),
       themeCompartment.of(proseEditorTheme),
       persistExt,
+      // Page-specific extras (e.g. the tour's hover-explanation
+      // tooltips). Built here so callers reuse the exact CM module
+      // instances resolved through the shared importmap. The value may
+      // be a single extension or an array; CodeMirror flattens nested
+      // arrays, so we include it as one element rather than spreading
+      // (spreading a non-iterable single extension would throw).
+      typeof features.buildExtraExtensions === "function"
+        ? features.buildExtraExtensions(cmModules) || []
+        : [],
     ];
 
     editor = new EditorView({

--- a/static/tour_starter.rs
+++ b/static/tour_starter.rs
@@ -1,0 +1,123 @@
+#![allow(dead_code, unused_variables)]
+
+// A quick tour of Rust, on one page.
+// Hover any keyword or type for a one-line explanation.
+// You don't need to understand every detail yet. Just soak it in,
+// then press Run to watch World 1-1 play out.
+
+// `let` binds a name to a value. Bindings are immutable unless you add `mut`.
+fn basics() {
+    let player = "Mario"; // type inferred: a string slice (&str)
+    let mut coins = 0; // `mut` lets this one change
+    coins += 1;
+
+    let lives: u8 = 3; // an explicit type: unsigned 8-bit integer
+    let stats = (1, 1, 400); // a tuple groups values: (world, level, time)
+
+    // `if` is an expression: it evaluates to a value you can bind.
+    let status = if coins >= 100 {
+        "1-Up!"
+    } else {
+        "keep collecting"
+    };
+
+    // Two kinds of loop.
+    for enemy in ["Goomba", "Koopa"] {
+        // runs once per item
+    }
+    let mut timer = 10;
+    while timer > 0 {
+        timer -= 1;
+    }
+}
+
+// An `enum` is a type with a fixed set of variants. Variants can carry data.
+enum PowerUp {
+    Small,
+    Mushroom,
+    Star(u32), // this variant holds the seconds of invincibility left
+}
+
+// A `struct` groups related fields under one named type.
+struct Player {
+    name: String,
+    power: PowerUp,
+}
+
+// A `trait` describes behavior that many types can share.
+trait Jump {
+    fn jump(&self);
+}
+
+// Implement the `Jump` behavior for our `Player`.
+impl Jump for Player {
+    fn jump(&self) {
+        // `match` is exhaustive: every variant must be handled.
+        match self.power {
+            PowerUp::Star(secs) => println!("{} leaps, invincible for {secs}s!", self.name),
+            PowerUp::Mushroom => println!("{} takes a high jump!", self.name),
+            PowerUp::Small => println!("{} hops.", self.name),
+        }
+    }
+}
+
+// Ownership: every value has one owner. Assigning it hands ownership over.
+fn ownership() {
+    let shell = String::from("green shell");
+    let kicked = shell; // `shell` is moved into `kicked`
+    // println!("{shell}"); // would not compile: `shell` no longer owns the value
+    println!("Mario kicks the {kicked}.");
+}
+
+// Borrowing: lend a value with `&` instead of giving it away.
+fn add_points(score: &mut i32) {
+    *score += 100; // `*` writes through the mutable reference
+}
+fn report(score: &i32) {
+    println!("Score: {score}"); // a shared `&` reference is read-only
+}
+
+// `Option<T>` models a value that might be missing. Rust has no null.
+fn hit_block(empty: bool) -> Option<&'static str> {
+    if empty { None } else { Some("coin") }
+}
+
+// `Result<T, E>` models an operation that can fail. Rust has no exceptions.
+fn enter_pipe(id: u8) -> Result<&'static str, &'static str> {
+    match id {
+        1 => Ok("warp zone"),
+        _ => Err("piranha plant!"),
+    }
+}
+
+// Every program starts at `main`.
+fn main() {
+    let mut mario = Player {
+        name: String::from("Mario"),
+        power: PowerUp::Mushroom,
+    };
+
+    println!("World 1-1");
+    mario.jump();
+
+    // `if let` runs the block only when the Option is `Some`.
+    if let Some(item) = hit_block(false) {
+        println!("Mario found a {item}!");
+    }
+
+    let mut score = 0;
+    add_points(&mut score); // lend `score` mutably
+    report(&score); // lend `score` just to read it
+
+    // Grab a star and become invincible.
+    mario.power = PowerUp::Star(10);
+    mario.jump();
+
+    // Handle both outcomes of a fallible call with `match`.
+    match enter_pipe(1) {
+        Ok(place) => println!("Mario enters the {place}."),
+        Err(danger) => println!("Ouch: {danger}"),
+    }
+
+    println!("World 1-1 clear! Flagpole reached. 🏁");
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1550,6 +1550,78 @@
                 font-style: italic;
             }
 
+            /* ---------- Next-chapter CTA ---------- */
+            /* Rendered by `templates/partials/next_chapter_cta.html` at
+               the bottom of exercise pages and the quick tour. Exercise
+               pages add `.is-locked` to hide it until the chapter is
+               completed (revealed by the run-success hook in
+               `exercise.html`); the tour leaves it always visible. */
+            .next-chapter-cta {
+                margin: 3rem auto 0;
+                max-width: 32rem;
+                text-align: center;
+            }
+            .next-chapter-cta.is-locked {
+                display: none;
+            }
+            .next-chapter-btn {
+                display: inline-grid;
+                grid-template-columns: 1fr auto;
+                grid-template-rows: auto auto;
+                column-gap: 1rem;
+                row-gap: 0.15rem;
+                align-items: center;
+                text-align: left;
+                text-decoration: none;
+                padding: 1rem 1.5rem;
+                min-height: auto;
+                height: auto;
+                font-size: 1rem;
+            }
+            .next-chapter-btn:hover,
+            .next-chapter-btn:focus-visible {
+                text-decoration: none;
+            }
+            .next-chapter-eyebrow {
+                grid-column: 1;
+                grid-row: 1;
+                font-size: 0.7rem;
+                text-transform: uppercase;
+                letter-spacing: 0.18em;
+                font-weight: 600;
+                opacity: 0.8;
+            }
+            .next-chapter-title {
+                grid-column: 1;
+                grid-row: 2;
+                display: inline-flex;
+                align-items: baseline;
+                gap: 0.55rem;
+                font-size: 1.1rem;
+                font-weight: 600;
+                line-height: 1.2;
+            }
+            .next-chapter-num {
+                font-family:
+                    "JetBrains Mono", "SF Mono", Monaco, Menlo, Consolas,
+                    monospace;
+                font-size: 0.95rem;
+                font-weight: 600;
+                opacity: 0.85;
+                font-variant-numeric: tabular-nums;
+            }
+            .next-chapter-arrow {
+                grid-column: 2;
+                grid-row: 1 / span 2;
+                font-size: 1.4rem;
+                line-height: 1;
+                transition: transform 0.15s ease;
+            }
+            .next-chapter-btn:hover .next-chapter-arrow,
+            .next-chapter-btn:focus-visible .next-chapter-arrow {
+                transform: translateX(0.2rem);
+            }
+
             /* ---------- Quiz block (inline on quiz chapters) ---------- */
             /* Rendered by `Quiz::render_html` in src/exercises.rs and
                wired up by `static/js/quiz.js`. Lives inside the chapter

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -112,6 +112,11 @@ corrode{% endblock %} {% block topbar %}{% endblock %} {% block content %}
             tell you when you're done. Most take five to ten minutes. Skip ahead
             if a chapter feels familiar, come back when something clicks.
         </p>
+        <p class="book-tour-link">
+            Want the big picture again?
+            <a href="/tour">A Quick Tour of Rust →</a> shows the whole language
+            on a single page.
+        </p>
         {% match team_token %} {% when Some with (token) %} {% match ulid %} {%
         when Some with (u) %}
         <p class="book-team-link">
@@ -141,6 +146,11 @@ corrode{% endblock %} {% block topbar %}{% endblock %} {% block content %}
             four hands-on mini-projects: a password validator, a word counter,
             an env-file parser, and a CSV parser. Skip ahead if a chapter feels
             familiar; come back when something clicks.
+        </p>
+        <p class="book-tour-link">
+            New to Rust? Start with
+            <a href="/tour">A Quick Tour of Rust →</a>, the whole language on a
+            single page before the chapters slow it all down.
         </p>
     </section>
 
@@ -265,10 +275,10 @@ fn main() {
         {#
           Inline signup card. Hidden until the warm-up's first successful
           run. Once visible, the form posts the chosen name to
-          `/api/register` (JSON), gets a fresh ULID back, and redirects to
-          chapter 1 (`00_integers`) under that ULID. The fallback `<a>`
-          right below the form lets visitors who'd rather skip the save
-          file jump straight in as anonymous.
+          `/api/register` (JSON), gets a fresh ULID back, and sends the
+          learner into the quick tour (`/tour/{ulid}`) under that ULID.
+          The fallback `<a>` right below the form lets visitors who'd
+          rather skip the save file head to the tour as anonymous.
         #}
         <div
             id="warmup-signup"
@@ -300,7 +310,7 @@ fn main() {
                     class="btn book-acquainted-signup-submit"
                     id="warmup-signup-submit"
                 >
-                    Continue to chapter 1 →
+                    Start the quick tour →
                 </button>
             </form>
             <p
@@ -311,9 +321,7 @@ fn main() {
             ></p>
             <p class="book-acquainted-signup-skip">
                 Or
-                <a href="/exercise/{{ next_slug }}"
-                    >jump in without signing up</a
-                >
+                <a href="/tour">jump in without signing up</a>
                 &mdash; you can always sign up later from any chapter.
             </p>
         </div>
@@ -354,7 +362,6 @@ fn main() {
         const signupName = document.getElementById("warmup-signup-name");
         const signupSubmit = document.getElementById("warmup-signup-submit");
         const signupError = document.getElementById("warmup-signup-error");
-        const NEXT_SLUG = "{{ next_slug }}";
 
         function revealSignup() {
             if (!signupCard.hasAttribute("hidden")) return;
@@ -418,10 +425,10 @@ fn main() {
         });
 
         // ---- Inline signup ---------------------------------------------
-        // POSTs the chosen name to /api/register (JSON), then redirects
-        // to chapter 1 under the freshly minted ULID. The endpoint
-        // validates the name server-side via `Name::try_from`; we surface
-        // any 4xx as inline error text rather than alerting.
+        // POSTs the chosen name to /api/register (JSON), then sends the
+        // learner into the quick tour under the freshly minted ULID. The
+        // endpoint validates the name server-side via `Name::try_from`;
+        // we surface any 4xx as inline error text rather than alerting.
         signupForm.addEventListener("submit", async (e) => {
             e.preventDefault();
             const name = (signupName.value || "").trim();
@@ -459,7 +466,7 @@ fn main() {
                     signupName.disabled = false;
                     return;
                 }
-                window.location.href = `/exercise/${data.ulid}/${NEXT_SLUG}`;
+                window.location.href = `/tour/${data.ulid}`;
             } catch (err) {
                 console.error(err);
                 signupError.textContent =

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -70,6 +70,19 @@ with (u) %}
                     %}
                     {%
                     match
+                    d.href
+                    %}{%
+                    when
+                    Some
+                    with
+                    (h)
+                    %}
+                    href="{{ h }}"
+                    {%
+                    when
+                    None
+                    %}{%
+                    match
                     ulid
                     %}{%
                     when
@@ -84,6 +97,8 @@ with (u) %}
                     %}
                     href="/exercise/{{ d.slug }}"
                     {%
+                    endmatch
+                    %}{%
                     endmatch
                     %}
                     class="chapter-picker-item{% if d.current %} is-current{% endif %}"
@@ -544,13 +559,14 @@ when None %}Join a team{% endmatch %}{% endblock %} {% block content %}
     there's nothing to wire up. #}
     <script src="/static/js/quiz.js" defer></script>
 
-    {% match next_dot %} {% when Some with (n) %} {% if ulid.is_none() &&
-    exercise.wants_signup_on_pass() %} {# Anonymous welcome chapter: the inline
-    signup card stands in for the next-chapter button. It starts hidden and is
-    revealed by the `signup_on_pass` pass hook in applyChapterDirectives() the
-    moment the user gets the first exercise to compile. The hidden `next` field
-    round-trips through `/register` so the redirect lands on the next chapter
-    (now with the fresh ULID), not the dashboard. #}
+    {% if next_dot.is_some() && ulid.is_none() &&
+    exercise.wants_signup_on_pass() %} {% match next_dot %} {% when Some with
+    (n) %} {# Anonymous welcome chapter: the inline signup card stands in for
+    the next-chapter button. It starts hidden and is revealed by the
+    `signup_on_pass` pass hook in applyChapterDirectives() the moment the user
+    gets the first exercise to compile. The hidden `next` field round-trips
+    through `/register` so the redirect lands on the next chapter (now with the
+    fresh ULID), not the dashboard. #}
     <section
         id="inline-signup"
         class="inline-signup"
@@ -584,33 +600,9 @@ when None %}Join a team{% endmatch %}{% endblock %} {% block content %}
             <a href="/exercise/{{ n.slug }}">Continue without saving</a>.
         </p>
     </section>
-    {% else %}
-    <section
-        class="next-chapter-cta{% if ulid.is_some() && !current_status.completed %} is-locked{% endif %}"
-        aria-label="Continue"
-    >
-        {% match ulid %} {% when Some with (u) %}
-        <a class="btn next-chapter-btn" href="/exercise/{{ u }}/{{ n.slug }}">
-            <span class="next-chapter-eyebrow">Next chapter</span>
-            <span class="next-chapter-title"
-                ><span class="next-chapter-num">{{ n.number }}</span>{{ n.title
-                }}</span
-            >
-            <span class="next-chapter-arrow" aria-hidden="true">→</span>
-        </a>
-        {% when None %}
-        <a class="btn next-chapter-btn" href="/exercise/{{ n.slug }}">
-            <span class="next-chapter-eyebrow">Next chapter</span>
-            <span class="next-chapter-title"
-                ><span class="next-chapter-num">{{ n.number }}</span>{{ n.title
-                }}</span
-            >
-            <span class="next-chapter-arrow" aria-hidden="true">→</span>
-        </a>
-        {% endmatch %}
-    </section>
-    {% endif %} {% when None %} {% endmatch %} {% if exercise.shows_toc() %} {%
-    include "partials/chapter_list.html" %} {% endif %}
+    {% when None %} {% endmatch %} {% else %} {% include
+    "partials/next_chapter_cta.html" %} {% endif %} {% if exercise.shows_toc()
+    %} {% include "partials/chapter_list.html" %} {% endif %}
 </div>
 
 <script type="module">
@@ -1369,10 +1361,6 @@ when None %}Join a team{% endmatch %}{% endblock %} {% block content %}
         font-weight: 600;
     }
 
-    .next-chapter-cta.is-locked {
-        display: none;
-    }
-
     /* ---- Inline signup card (welcome chapter, anonymous) ---- */
     .inline-signup {
         margin: 3rem auto 0;
@@ -1450,67 +1438,6 @@ when None %}Join a team{% endmatch %}{% endblock %} {% block content %}
     .inline-signup-skip a:hover,
     .inline-signup-skip a:focus-visible {
         color: var(--color-primary);
-    }
-    .next-chapter-cta {
-        margin: 3rem auto 0;
-        max-width: 32rem;
-        text-align: center;
-    }
-    .next-chapter-btn {
-        display: inline-grid;
-        grid-template-columns: 1fr auto;
-        grid-template-rows: auto auto;
-        column-gap: 1rem;
-        row-gap: 0.15rem;
-        align-items: center;
-        text-align: left;
-        text-decoration: none;
-        padding: 1rem 1.5rem;
-        min-height: auto;
-        height: auto;
-        font-size: 1rem;
-    }
-    .next-chapter-btn:hover,
-    .next-chapter-btn:focus-visible {
-        text-decoration: none;
-    }
-    .next-chapter-eyebrow {
-        grid-column: 1;
-        grid-row: 1;
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        letter-spacing: 0.18em;
-        font-weight: 600;
-        opacity: 0.8;
-    }
-    .next-chapter-title {
-        grid-column: 1;
-        grid-row: 2;
-        display: inline-flex;
-        align-items: baseline;
-        gap: 0.55rem;
-        font-size: 1.1rem;
-        font-weight: 600;
-        line-height: 1.2;
-    }
-    .next-chapter-num {
-        font-family:
-            "JetBrains Mono", "SF Mono", Monaco, Menlo, Consolas, monospace;
-        font-size: 0.95rem;
-        font-weight: 600;
-        opacity: 0.85;
-        font-variant-numeric: tabular-nums;
-    }
-    .next-chapter-arrow {
-        grid-column: 2;
-        grid-row: 1 / span 2;
-        font-size: 1.4rem;
-        line-height: 1;
-        transition: transform 0.15s ease;
-    }
-    .next-chapter-btn:hover .next-chapter-arrow,
-    .next-chapter-btn:focus-visible .next-chapter-arrow {
-        transform: translateX(0.2rem);
     }
 
     /* The bottom "All exercises" chapter list and the homepage TOC both

--- a/templates/partials/chapter_list.html
+++ b/templates/partials/chapter_list.html
@@ -10,7 +10,7 @@ template variables: - dots: Vec<ProgressDot>
             <nav
                 class="chapter-list"
                 aria-label="All exercises"
-                style="--chapter-rows: {{ (dots.len() + 1) / 2 }}"
+                style="--chapter-rows: {{ chapter_rows }}"
             >
                 {% for d in dots %} {% if !d.is_bonus %} {% if d.current %}
                 <span
@@ -22,7 +22,16 @@ template variables: - dots: Vec<ProgressDot>
                     <span class="chapter-title">{{ d.title }}</span>
                     <span class="chapter-mark" aria-hidden="true"></span>
                 </span>
-                {% else %} {% match ulid %} {% when Some with (u) %}
+                {% else %} {% match d.href %} {% when Some with (h) %}
+                <a
+                    href="{{ h }}"
+                    class="chapter-row{% if d.is_quiz %} quiz{% endif %}"
+                >
+                    <span class="chapter-num">{{ d.number }}</span>
+                    <span class="chapter-title">{{ d.title }}</span>
+                    <span class="chapter-mark" aria-hidden="true"></span>
+                </a>
+                {% when None %} {% match ulid %} {% when Some with (u) %}
                 <a
                     href="/exercise/{{ u }}/{{ d.slug }}"
                     class="chapter-row{% if d.attempted %} attempted{% endif %}{% if d.completed %} completed{% endif %}{% if d.perfected %} perfected{% endif %}{% if d.is_quiz %} quiz{% endif %}"
@@ -40,7 +49,8 @@ template variables: - dots: Vec<ProgressDot>
                     <span class="chapter-title">{{ d.title }}</span>
                     <span class="chapter-mark" aria-hidden="true"></span>
                 </a>
-                {% endmatch %} {% endif %} {% endif %} {% endfor %}
+                {% endmatch %} {% endmatch %} {% endif %} {% endif %} {% endfor
+                %}
             </nav></span
         ></String
     ></ProgressDot

--- a/templates/partials/next_chapter_cta.html
+++ b/templates/partials/next_chapter_cta.html
@@ -1,0 +1,39 @@
+{# Shared "Next chapter" call-to-action button, used at the bottom of exercise
+pages and the quick tour. Required template fields: next_dot (the chapter to
+link to; renders nothing when absent), ulid (participant prefix on the link when
+present), and next_locked (renders hidden via `.is-locked`; exercise pages
+reveal it once the chapter is completed, the tour leaves it false). The
+`.next-chapter-*` styles live in base.html. #} {% match next_dot %} {% when Some
+with (n) %}
+<section
+    class="next-chapter-cta{% if next_locked %} is-locked{% endif %}"
+    aria-label="Continue"
+>
+    <a
+        class="btn next-chapter-btn"
+        {%
+        match
+        ulid
+        %}{%
+        when
+        Some
+        with
+        (u)
+        %}href="/exercise/{{ u }}/{{ n.slug }}"
+        {%
+        when
+        None
+        %}href="/exercise/{{ n.slug }}"
+        {%
+        endmatch
+        %}
+    >
+        <span class="next-chapter-eyebrow">Next chapter</span>
+        <span class="next-chapter-title"
+            ><span class="next-chapter-num">{{ n.number }}</span>{{ n.title
+            }}</span
+        >
+        <span class="next-chapter-arrow" aria-hidden="true">→</span>
+    </a>
+</section>
+{% when None %} {% endmatch %}

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -1,0 +1,407 @@
+{% extends "base.html" %} {% block title %}A Quick Tour of Rust | corrode Rust
+Course{% endblock %} {% block content %}
+<div class="container">
+    <div class="exercise-header">
+        <div class="chapter-eyebrow">Preamble</div>
+        <h1 class="exercise-title">A Quick Tour of Rust</h1>
+    </div>
+
+    <div class="chapter-prose exercise-prose">
+        <p>
+            Here is most of Rust on a single page, told as a tiny game. Don't
+            try to understand every detail. Just read it top to bottom and let
+            the shapes sink in. The whole rest of the course is spent slowing
+            each of these ideas down, one chapter at a time.
+        </p>
+        <p>
+            <strong>Hover over any keyword or type</strong> for a one-line
+            explanation, and press <strong>Run</strong> to watch World 1-1 play
+            out. The code is yours to edit, too.
+        </p>
+    </div>
+
+    <section
+        class="exercise-section"
+        data-step-id="tour"
+        data-exercise-key="tour"
+    >
+        <div class="exercise-section-head">
+            <div></div>
+            <div class="exercise-actions">
+                <span
+                    data-role="action-status"
+                    class="action-status"
+                    aria-live="polite"
+                ></span>
+                <button
+                    type="button"
+                    class="btn btn-secondary btn-reset"
+                    data-role="reset-btn"
+                    title="Restore the original tour code"
+                >
+                    Reset
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-secondary"
+                    data-role="format-btn"
+                    title="Format the code with rustfmt"
+                >
+                    Format
+                </button>
+                <button
+                    type="button"
+                    class="btn"
+                    data-role="run-btn"
+                    title="Run on play.rust-lang.org (⌘/Ctrl+Enter)"
+                >
+                    ▶ Run
+                </button>
+            </div>
+        </div>
+
+        <div style="position: relative">
+            <textarea
+                data-role="editor-fallback"
+                spellcheck="false"
+                style="
+                    width: 100%;
+                    min-height: 32rem;
+                    font-family:
+                        &quot;JetBrains Mono&quot;, &quot;SF Mono&quot;, Monaco,
+                        monospace;
+                    font-size: 0.9rem;
+                    padding: 1rem;
+                    border: 1px solid var(--color-border);
+                    border-radius: 12px;
+                    background-color: var(--color-background);
+                    color: var(--color-text);
+                    resize: vertical;
+                "
+            >
+{{ starter }}</textarea
+            >
+            <div data-role="editor-mount" style="display: none"></div>
+        </div>
+
+        <div
+            data-role="run-status-row"
+            style="
+                margin-top: 0.75rem;
+                min-height: 1.2rem;
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+            "
+        >
+            <span
+                data-role="run-spinner"
+                class="run-spinner"
+                aria-hidden="true"
+                style="display: none"
+            ></span>
+            <span
+                data-role="run-status"
+                style="color: var(--color-text-muted); font-size: 0.9rem"
+                aria-live="polite"
+            ></span>
+        </div>
+
+        <div data-role="output-panel" style="display: none; margin-top: 1rem">
+            <h3 style="margin: 0 0 0.5rem 0; font-size: 1rem">Output</h3>
+            <pre
+                data-role="output-stderr"
+                style="
+                    margin: 0;
+                    padding: 0.85rem 1rem;
+                    background-color: var(--color-background);
+                    border: 1px solid var(--color-border);
+                    border-radius: 12px;
+                    overflow-x: auto;
+                    font-family:
+                        &quot;JetBrains Mono&quot;, &quot;SF Mono&quot;, Monaco,
+                        monospace;
+                    font-size: 0.8rem;
+                    white-space: pre-wrap;
+                "
+            ></pre>
+        </div>
+    </section>
+
+    {% include "partials/next_chapter_cta.html" %}
+</div>
+
+<script type="module">
+    // One annotated, runnable code box. We reuse the playground's
+    // inline editor (CodeMirror + the /api/run proxy) in run-only mode,
+    // and layer concept-class hover explanations on top via the
+    // `buildExtraExtensions` hook. The lookup is deliberately text-based
+    // (grab the token under the pointer, look it up in EXPLAIN) so it
+    // stays robust and minimal instead of depending on Lezer node names.
+
+    // Each entry is the canonical, one-line meaning of a language
+    // construct. Same word, same explanation, wherever it appears.
+    const EXPLAIN = {
+        // Bindings and mutability
+        let: "Binds a name to a value. Immutable unless you add `mut`.",
+        mut: "Makes a binding or reference mutable, so its value can change.",
+        // Functions and flow
+        fn: "Defines a function.",
+        if: "A conditional. In Rust `if` is an expression: it evaluates to a value.",
+        else: "The branch taken when the `if` condition is false.",
+        for: "Loops once over each item of a collection or iterator.",
+        while: "Loops for as long as its condition stays true.",
+        match: "Compares a value against patterns. Must be exhaustive: every case handled.",
+        return: "Returns a value early from a function.",
+        // Types that define data
+        enum: "A type with a fixed set of variants. Variants can carry their own data.",
+        struct: "A type that groups related fields together under one name.",
+        trait: "A set of methods a type can implement. Shared behavior, like an interface.",
+        impl: "Implements methods, or a trait, for a type.",
+        self: "The receiver: the instance the method was called on.",
+        // Primitive and standard types
+        bool: "A boolean: either `true` or `false`.",
+        u8: "An unsigned 8-bit integer, holding 0 to 255.",
+        u32: "An unsigned 32-bit integer (can't be negative).",
+        i32: "A signed 32-bit integer, Rust's everyday default.",
+        str: "A borrowed string slice. You usually see it as `&str`.",
+        String: "An owned, growable, heap-allocated string.",
+        // The two pillars of error handling
+        Option: "A value that's either present (`Some`) or absent (`None`). Rust's answer to null.",
+        Result: "The outcome of something that can fail: `Ok` on success, `Err` on failure.",
+        Some: "The `Option` variant that wraps a present value.",
+        None: "The `Option` variant for an absent value.",
+        Ok: "The `Result` variant carrying a success value.",
+        Err: "The `Result` variant carrying an error.",
+        // Macros and operators
+        "println!":
+            "Prints a line to standard output. The `!` marks it as a macro.",
+        println:
+            "Prints a line to standard output. The `!` marks it as a macro.",
+        "&": "A reference: borrows a value instead of taking ownership.",
+        "&mut": "A mutable borrow: exclusive, writable access. Only one at a time.",
+        "*": "Dereferences a reference to read or write the value it points to.",
+        "::": "Path separator, e.g. `PowerUp::Star` or `String::from`.",
+        "->": "Introduces the type a function returns.",
+        // The example's own types, for orientation
+        PowerUp: "This tour's example enum: Mario's current power state.",
+        Player: "This tour's example struct: a name plus a power state.",
+        Jump: "This tour's example trait: the shared `jump` behavior.",
+    };
+
+    const WORD = /[A-Za-z0-9_]/;
+
+    // Resolve the token under `pos` to a { from, to, key } we can explain,
+    // or null. If the cursor sits on a word character we grab the whole
+    // identifier (plus a trailing `!` so `println!` reads as one token);
+    // otherwise we recognise a few operators by their characters, so
+    // hovering directly on `::`, `->`, `&`, or `*` works too.
+    function tokenAt(state, pos) {
+        const line = state.doc.lineAt(pos);
+        const text = line.text;
+        const i = pos - line.from;
+        const here = text[i] || "";
+
+        if (WORD.test(here) || (here === "!" && WORD.test(text[i - 1] || ""))) {
+            let a = i;
+            let b = i;
+            while (a > 0 && WORD.test(text[a - 1])) a--;
+            while (b < text.length && WORD.test(text[b])) b++;
+            let end = b;
+            if (text[end] === "!") end++;
+            return {
+                from: line.from + a,
+                to: line.from + end,
+                key: text.slice(a, end),
+            };
+        }
+
+        if (here === "&") {
+            if (text.slice(i, i + 4) === "&mut")
+                return {
+                    from: line.from + i,
+                    to: line.from + i + 4,
+                    key: "&mut",
+                };
+            return { from: line.from + i, to: line.from + i + 1, key: "&" };
+        }
+        if (here === "*")
+            return { from: line.from + i, to: line.from + i + 1, key: "*" };
+        for (const op of ["::", "->"]) {
+            if (text.slice(i, i + 2) === op)
+                return { from: line.from + i, to: line.from + i + 2, key: op };
+            if (text.slice(i - 1, i + 1) === op)
+                return {
+                    from: line.from + i - 1,
+                    to: line.from + i + 1,
+                    key: op,
+                };
+        }
+        return null;
+    }
+
+    function buildTourHover(cm) {
+        const view = cm && cm.view;
+        const hoverTooltip = view && view.hoverTooltip;
+        if (typeof hoverTooltip !== "function") {
+            console.warn(
+                "tour: hoverTooltip unavailable; explanations disabled",
+            );
+            return [];
+        }
+        const ext = hoverTooltip(
+            (cmView, pos) => {
+                const tok = tokenAt(cmView.state, pos);
+                if (!tok) return null;
+                const body = EXPLAIN[tok.key];
+                if (!body) return null;
+                return {
+                    pos: tok.from,
+                    end: tok.to,
+                    above: true,
+                    create() {
+                        const dom = document.createElement("div");
+                        dom.className = "tour-tip";
+                        const k = document.createElement("code");
+                        k.className = "tour-tip-key";
+                        k.textContent = tok.key;
+                        const p = document.createElement("span");
+                        p.textContent = body;
+                        dom.appendChild(k);
+                        dom.appendChild(p);
+                        return { dom };
+                    },
+                };
+            },
+            { hoverTime: 80 },
+        );
+        // The inline editor sets `overflow: hidden` on `.cm-editor`, which
+        // clips tooltips rendered as its children. Render them into
+        // `document.body` so they're always visible.
+        const exts = [ext];
+        if (typeof view.tooltips === "function") {
+            exts.unshift(view.tooltips({ parent: document.body }));
+        }
+        return exts;
+    }
+
+    import("/static/js/inline-editor.js")
+        .then(({ mountInlineEditor }) => {
+            const section = document.querySelector(
+                '.exercise-section[data-step-id="tour"]',
+            );
+            if (!section) return;
+            const fallback = section.querySelector(
+                '[data-role="editor-fallback"]',
+            );
+            mountInlineEditor(section, {
+                starter: fallback ? fallback.value : "",
+                slug: "tour",
+                features: {
+                    vim: true,
+                    draftKey: "corrode:tour:draft",
+                    submit: null,
+                    testResults: false,
+                    copyButton: false,
+                    urlPlugin: false,
+                    syntaxHighlightOutput: false,
+                    runWithoutTests: true,
+                    buildExtraExtensions: buildTourHover,
+                },
+            });
+        })
+        .catch((err) => {
+            console.error("inline-editor module failed to load:", err);
+        });
+</script>
+
+<style>
+    .exercise-header {
+        margin: 1rem 0 1.5rem;
+    }
+    .chapter-eyebrow {
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        margin-bottom: 0.4rem;
+    }
+    .exercise-title {
+        font-size: 2rem;
+    }
+    .exercise-section {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 16px;
+        padding: 1.5rem;
+        margin-top: 1.5rem;
+    }
+    .exercise-section-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+    }
+    .exercise-actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .run-spinner {
+        width: 0.9rem;
+        height: 0.9rem;
+        border: 2px solid var(--color-border);
+        border-top-color: var(--color-primary);
+        border-radius: 50%;
+        animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+
+    .btn.btn-reset {
+        color: var(--color-text-muted);
+    }
+    .btn.btn-reset:hover {
+        color: var(--color-text);
+    }
+
+    .exercise-section[data-step-id="tour"] .cm-editor {
+        min-height: 32rem;
+    }
+
+    /* Hover-explanation tooltip. CodeMirror wraps it in `.cm-tooltip`;
+       we only style the inner `.tour-tip` content. */
+    .tour-tip {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        max-width: 22rem;
+        padding: 0.5rem 0.65rem;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        color: var(--color-text);
+    }
+    .tour-tip-key {
+        align-self: flex-start;
+        font-family: "JetBrains Mono", "SF Mono", Monaco, monospace;
+        font-size: 0.78rem;
+        color: var(--color-primary);
+        background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+        padding: 0.05rem 0.35rem;
+        border-radius: 5px;
+    }
+    .cm-tooltip:has(.tour-tip) {
+        border: 1px solid var(--color-border);
+        border-radius: 10px;
+        background: var(--color-surface);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    }
+</style>
+{% endblock %}


### PR DESCRIPTION
## What

Adds a read-only **"A Quick Tour of Rust"** preamble that shows most of the language on a single page, told as a tiny Super Mario program, before the slow per-concept chapters begin. The reader can just "soak it in," hover any keyword/type for a one-line explanation, and run/edit the code.

It sits right after the landing page and is the first entry in the table of contents.

## Highlights

- **`/tour` page** (`templates/tour.html`): one editable, runnable code box (reuses the playground's inline editor in run-only mode) with concept-class hover tooltips driven by a small dictionary + CodeMirror's `hoverTooltip`. Tooltips render into `document.body` so they aren't clipped by the editor's `overflow: hidden`.
- **Source** in `static/tour_starter.rs`, embedded via `include_str!`, kept as a real `.rs` file so it stays editable and syntax-highlighted. Verified it compiles and runs at edition 2024.
- **Navigation**: first TOC entry (number `0`), surfaced from the dashboard intro and the post-warm-up signup flow, which now funnels into the tour. The tour is ULID-aware (`/tour/{ulid}`) so a freshly signed-up learner keeps their progress context into chapter 1.
- **Shared CTA**: extracted the "Next chapter" button into `partials/next_chapter_cta.html` and moved its styles to `base.html`, so the tour and exercise pages share one component. The tour ends on that same button into chapter 1.
- **TOC fix**: the two-column split now balances on the visible (non-bonus) row count via a `chapter_rows()` helper, so columns stay even as chapters are added/removed.
- **Inline editor**: added a `features.buildExtraExtensions` hook so pages can layer extra CodeMirror extensions while reusing the shared module instances.

## Testing

- `cargo check` and `cargo fmt --check` pass.
- `rustc --edition 2024` on the tour source compiles and prints the expected World 1-1 playthrough.
- Verified in a browser: hover tooltips work, the TOC columns are balanced (13/12), and the tour's next-chapter link resolves to `/exercise/integers` (anonymous) and `/exercise/{ulid}/integers` (with ULID).
