### PR TITLE
Remove answer-revealing exercise hints

### DIFF
--- a/examples/16_traits/2_display_temperature.rs
+++ b/examples/16_traits/2_display_temperature.rs
@@ -10,9 +10,6 @@ struct Temperature {
 ///   - `Temperature { celsius: 21.5 }`  → `"21.5°C"`
 ///   - `Temperature { celsius: -3.0 }`  → `"-3.0°C"`
 ///   - `Temperature { celsius: 100.0 }` → `"100.0°C"`
-///
-/// Hint: `write!(f, "{:.1}°C", self.celsius)` does the whole job.
-/// The `:.1` is the same format specifier you'd use in `println!`.
 impl fmt::Display for Temperature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         todo!()

--- a/examples/21_environment_file_parser/4_get_var.md
+++ b/examples/21_environment_file_parser/4_get_var.md
@@ -3,14 +3,12 @@
 Configuration values are stored as strings, but consumers want `u16` ports, `bool` flags, and so on.
 Rather than write one helper per type, declare a generic function bounded by `FromStr` and let the caller pick the type at the call site with a turbofish or a type annotation.
 
-Inside the body, `env.get(key)?` short-circuits on a missing key and `.parse().ok()` collapses the parse `Result` into an `Option`.
-Don't try to `?` the parse: `T::Err` is unconstrained here and would need an extra `From` bound.
+Return `None` both when the key is missing and when its value cannot be parsed as the requested type.
+The standard library methods below provide the pieces; your task is to combine them.
 
 ## Useful from the standard library
 
 - [`HashMap::get`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.get) returns `Option<&String>`.
-  The `?` propagates the missing-key case as `None`.
 - [`str::parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) uses [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) to produce `Result<T, T::Err>`.
   That's the trait the `where` clause is asking for.
-- [`Result::ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok) drops the error and yields `Option<T>`, exactly the function's return type.
-- The body fits on one line: `env.get(key)?.parse().ok()`.
+- [`Result::ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok) drops the error and yields `Option<T>`, matching the function's return type.

--- a/examples/21_environment_file_parser/4_get_var.rs
+++ b/examples/21_environment_file_parser/4_get_var.rs
@@ -2,12 +2,6 @@ use std::collections::HashMap;
 
 /// Gets an environment variable with type conversion.
 /// Parses the string value into the requested type.
-///
-/// Hint: the natural solution is `env.get(key)?.parse().ok()`. Don't try to
-/// `?` the parse: `T::Err` is unconstrained here, so `?` would need a
-/// `From<T::Err>` bound that we haven't added. `.ok()` collapses
-/// `Result<T, T::Err>` into `Option<T>`, which is what the signature
-/// returns anyway.
 fn get_env_var<T>(env: &HashMap<String, String>, key: &str) -> Option<T>
 where
     T: std::str::FromStr,

--- a/solutions/16_traits/2_display_temperature.rs
+++ b/solutions/16_traits/2_display_temperature.rs
@@ -10,9 +10,6 @@ struct Temperature {
 ///   - `Temperature { celsius: 21.5 }`  → `"21.5°C"`
 ///   - `Temperature { celsius: -3.0 }`  → `"-3.0°C"`
 ///   - `Temperature { celsius: 100.0 }` → `"100.0°C"`
-///
-/// Hint: `write!(f, "{:.1}°C", self.celsius)` does the whole job.
-/// The `:.1` is the same format specifier you'd use in `println!`.
 impl fmt::Display for Temperature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:.1}°C", self.celsius)

--- a/solutions/21_environment_file_parser/4_get_var.rs
+++ b/solutions/21_environment_file_parser/4_get_var.rs
@@ -2,12 +2,6 @@ use std::collections::HashMap;
 
 /// Gets an environment variable with type conversion.
 /// Parses the string value into the requested type.
-///
-/// Hint: the natural solution is `env.get(key)?.parse().ok()`. Don't try to
-/// `?` the parse: `T::Err` is unconstrained here, so `?` would need a
-/// `From<T::Err>` bound that we haven't added. `.ok()` collapses
-/// `Result<T, T::Err>` into `Option<T>`, which is what the signature
-/// returns anyway.
 fn get_env_var<T>(env: &HashMap<String, String>, key: &str) -> Option<T>
 where
     T: std::str::FromStr,


### PR DESCRIPTION
## Summary

- remove the complete get_env_var expression from the learner-facing doc comment and prose
- keep the required behavior and relevant standard-library APIs without composing the answer
- remove the complete write! call from display_temperature's doc comment
- mirror documentation cleanup in solution files so revealed/reference code stays consistent

## Validation

- cargo fmt --all --check
- cargo clippy --locked --lib --bins -- -D warnings
- cargo test --locked --lib --bins
- ./scripts/check-examples.sh
- REQUIRE_COMPLETE=1 ./scripts/check-solutions.sh (75/75)
